### PR TITLE
Remove -std=c++11 for libpqxx and getplot.cgi

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -19,7 +19,7 @@ RUN cd /opt \
     && rm libpqxx-6.4.5_fixed.tar.gz \
     && cd libpqxx-6.4.5 \
     && mkdir install \
-    && CXXFLAGS=-std=c++11 ./configure --disable-documentation --enable-shared --prefix=/opt/libpqxx-6.4.5/install \
+    && ./configure --disable-documentation --enable-shared --prefix=/opt/libpqxx-6.4.5/install \
     && make -j`nproc --all` \
     && make install
 

--- a/cgi-bin/Makefile
+++ b/cgi-bin/Makefile
@@ -23,7 +23,7 @@ sendcommand2nopadding.cgi: sendcommand2nopadding.cpp
 	chmod a+x $@
 
 getplot.cgi: getplot.cpp
-	$(CXX) -o $@ $< $(CXXFLAGS) -std=c++11 -Wno-attributes -lpqxx -lpq
+	$(CXX) -o $@ $< $(CXXFLAGS) -Wno-attributes -lpqxx -lpq
 	chmod a+x $@
 
 clean:


### PR DESCRIPTION
Old container was based on CentOS 7 with GCC defaulting to C++03 standard, and this flag was required for C++11 features. With Rocky Linux 9 it defaults to C++17, so this flag is no longer needed.

Please remember to rebuild the public container after merging.