### PR TITLE
Introduce tooldaq.js -- a new API for the web server

### DIFF
--- a/cgi-bin/Makefile
+++ b/cgi-bin/Makefile
@@ -8,11 +8,14 @@ lib_dirs     = $(addprefix -L $(Dependencies)/,$(addsuffix /lib,$(libs)))
 CXXFLAGS ?= -O3 -pipe
 CXXFLAGS += $(include_dirs) $(lib_dirs)
 
-programs = sendcommand2.cgi sendcommand2nopadding.cgi
+programs = command.cgi sendcommand2.cgi sendcommand2nopadding.cgi
 
 .PHONY: all clean
 
 all: $(programs)
+
+command.cgi: command.cpp
+	$(CXX) -o $@ $< $(CXXFLAGS) -lzmq -lStore
 
 sendcommand2.cgi: sendcommand2.cpp
 	$(CXX) -o $@ $< $(CXXFLAGS) -lzmq -lcgicc -lStore

--- a/cgi-bin/command.cpp
+++ b/cgi-bin/command.cpp
@@ -137,7 +137,6 @@ int main() {
     const int timeout = 5000;
     socket.setsockopt(ZMQ_RCVTIMEO,  timeout);
     socket.setsockopt(ZMQ_SNDTIMEO,  timeout);
-    socket.setsockopt(ZMQ_IMMEDIATE, 1);
 
     {
       if (debug) *debug << "connecting to socket" << std::endl;

--- a/cgi-bin/command.cpp
+++ b/cgi-bin/command.cpp
@@ -1,4 +1,6 @@
+#include <chrono>
 #include <iostream>
+#include <iomanip>
 #include <stdexcept>
 #include <sstream>
 #include <string>
@@ -11,8 +13,6 @@
 #include <Store.h>
 
 #include <zmq.hpp>
-
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 // set to 1 to enable debug output
 #if 0
@@ -116,12 +116,14 @@ int main() {
     std::string json;
     {
       ToolFramework::Store store;
-      store.Set(
-          "msg_time",
-          boost::posix_time::to_iso_extended_string(
-            boost::posix_time::microsec_clock::universal_time()
-          ) + "Z"
+
+      auto now = std::chrono::system_clock::to_time_t(
+          std::chrono::system_clock::now()
       );
+      std::stringstream ss;
+      ss << std::put_time(std::localtime(&now), "%F %TZ%z");
+      store.Set("msg_time", ss.str());
+
       store.Set("msg_type",  "Command");
       store.Set("msg_value", command);
       store.Set("var1",      argument);

--- a/cgi-bin/command.cpp
+++ b/cgi-bin/command.cpp
@@ -14,11 +14,6 @@
 
 #include <zmq.hpp>
 
-// set to 1 to enable debug output
-#if 0
-#define DEBUG_FILE "/tmp/command.log"
-#endif
-
 std::string uri_decode(std::string string) {
   size_t i = 0;
   while (true) {
@@ -93,15 +88,12 @@ std::string& get_argument(
   return argument->second;
 };
 
-int main() {
+int main(int argc, char** argv) {
   try {
-    std::ofstream* debug =
-#ifdef DEBUG_FILE
-        new std::ofstream(DEBUG_FILE, std::ios::out)
-#else
-        nullptr
-#endif
-    ;
+    std::ofstream* debug = nullptr;
+    if (argc > 2 && strcmp(argv[1], "-d") == 0)
+      debug = new std::ofstream(argv[2], std::ios::out);
+
 
     auto args = get_arguments();
     std::string& ip   = get_argument(args, "ip");

--- a/cgi-bin/command.cpp
+++ b/cgi-bin/command.cpp
@@ -1,0 +1,196 @@
+#include <iostream>
+#include <stdexcept>
+#include <sstream>
+#include <string>
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <Store.h>
+
+#include <zmq.hpp>
+
+#include <boost/date_time/posix_time/posix_time.hpp>
+
+// set to 1 to enable debug output
+#if 0
+#define DEBUG_FILE "/tmp/command.log"
+#endif
+
+std::string uri_decode(std::string string) {
+  size_t i = 0;
+  while (true) {
+    i = string.find('+', i);
+    if (i == std::string::npos) break;
+    string[i++] = ' ';
+  };
+
+  i = string.find('%');
+  if (i == std::string::npos) return string;
+
+  size_t j = i;
+  while (i < string.size())
+    if (string[i] == '%') {
+      if (!(i + 2 < string.size()
+            && isxdigit(string[i+1])
+            && isxdigit(string[i+2])))
+      {
+        std::stringstream ss;
+        ss
+          << "malformed URI sequence: \""
+          << string
+          << "\", position "
+          << i;
+        throw std::runtime_error(ss.str());
+      };
+
+      sscanf(&string[++i], "%2hhu", &string[j++]);
+      i += 2;
+    } else
+      string[j++] = string[i++];
+
+  return string;
+};
+
+std::unordered_map<std::string, std::string> get_arguments() {
+  std::unordered_map<std::string, std::string> result;
+
+  char* query = getenv("QUERY_STRING");
+  if (!query) return result;
+
+  char* begin = query;
+  char* split;
+  char* end;
+  do {
+    end = strchrnul(begin, '&');
+    split = strchr(begin, '=');
+    if (!split || split > end) {
+      std::stringstream ss;
+      ss << "Invalid query string: " << query;
+      throw std::runtime_error(ss.str());
+    };
+    result.emplace(
+        std::pair {
+          uri_decode(std::string(begin, split)),
+          uri_decode(std::string(split + 1, end))
+        }
+    );
+    begin = end + 1;
+  } while (*end);
+
+  return result;
+};
+
+std::string& get_argument(
+    std::unordered_map<std::string, std::string>& arguments,
+    const std::string& name
+) {
+  auto argument = arguments.find(name);
+  if (argument == arguments.end())
+    throw std::runtime_error("No required argument: " + name);
+  return argument->second;
+};
+
+int main() {
+  try {
+    std::ofstream* debug =
+#ifdef DEBUG_FILE
+        new std::ofstream(DEBUG_FILE, std::ios::out)
+#else
+        nullptr
+#endif
+    ;
+
+    auto args = get_arguments();
+    std::string& ip   = get_argument(args, "ip");
+    std::string& port = get_argument(args, "port");
+
+    std::string command;
+    std::string argument;
+    std::cin >> command >> std::ws;
+    std::getline(std::cin, argument, '\0');
+
+    if (debug) *debug << "command: '" << command << "', argument: '" << argument << '\'' << std::endl;
+    std::string json;
+    {
+      ToolFramework::Store store;
+      store.Set(
+          "msg_time",
+          boost::posix_time::to_iso_extended_string(
+            boost::posix_time::microsec_clock::universal_time()
+          ) + "Z"
+      );
+      store.Set("msg_type",  "Command");
+      store.Set("msg_value", command);
+      store.Set("var1",      argument);
+
+      store >> json;
+    };
+
+    if (debug) *debug << "opening zmq context" << std::endl;
+    zmq::context_t context(1);
+
+    if (debug) *debug << "creating socket" << std::endl;
+    zmq::socket_t socket(context, ZMQ_REQ);
+    const int timeout = 5000;
+    socket.setsockopt(ZMQ_RCVTIMEO,  timeout);
+    socket.setsockopt(ZMQ_SNDTIMEO,  timeout);
+    socket.setsockopt(ZMQ_IMMEDIATE, 1);
+
+    {
+      if (debug) *debug << "connecting to socket" << std::endl;
+      std::stringstream ss;
+      ss << "tcp://" << ip << ':' << port;
+      std::string s = ss.str();
+      socket.connect(s.c_str());
+    };
+
+    zmq::message_t send(json.size() + 1);
+    memcpy(send.data(), json.c_str(), json.size() + 1);
+
+    // FIXME should poll for listener before sending
+    if (debug) *debug << "sending '" << json << '\'' << std::endl;
+    bool ok = socket.send(send);
+    if (debug) *debug << "send success: " << ok << std::endl;
+    if (!ok) throw std::runtime_error("zmq send failed");
+
+    zmq::message_t receive;
+    if (debug) *debug << "receiving..." << std::endl;
+    // FIXME should poll for inbound before receiving
+
+    ok = socket.recv(&receive);
+    if (debug) *debug << "recv success: " << ok << std::endl;
+    if (!ok) throw std::runtime_error("zmq rcv failed");
+
+    size_t size = receive.size();
+    if (size == 0) throw std::runtime_error("zmq rcv got empty response");
+    std::string answer(size, 0); // one byte too many?
+    memcpy(answer.data(), receive.data(), receive.size());
+    if (debug) *debug << "got response: '" << answer << '\'' << std::endl;
+
+    ToolFramework::Store store;
+    store.JsonParser(answer);
+
+    {
+      std::string type;
+      if (!store.Get("msg_type", type))
+        throw std::runtime_error("Invalid reply: no 'msg_type'");
+      if (type != "Command Reply")
+        throw std::runtime_error(
+            "Invalid reply: expected 'Command Reply', got " + type
+        );
+    };
+
+    auto response = store.Get<std::string>("msg_value");
+
+    std::cout << "Content-type: text/plain\r\n\r\n" << response;
+  } catch (std::exception& e) {
+    std::cout
+      << "Content-type: text/plain\r\n"
+      << "Status: 500\r\n\r\n"
+      << e.what();
+  };
+  return 0;
+};

--- a/cgi-bin/db-query.cgi
+++ b/cgi-bin/db-query.cgi
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+#DEBUG_FILE=/tmp/${0%.cgi}.log
+
+if [[ -z $PGHOST ]]; then
+  export PGHOST=127.0.0.1
+fi
+if [[ -z $PGUSER ]]; then
+  export PGUSER=root
+fi
+if [[ -z $PGDATABASE ]]; then
+  export PGDATABASE=daq
+fi
+
+declare -A args
+
+while read -d = arg; do
+  read -d \& value
+  value=${value//+/ }                # decode URL encoding (' ' <=> '+')
+  value=$(echo -e "${value//%/\\x}") # decode %-encoding
+  args[$arg]=$value
+done <<< "$QUERY_STRING"
+
+query=${args[query]}
+
+format=${args[format]}
+header=${args[header]}
+
+if [[ -n $DEBUG_FILE ]]; then
+  {
+    date
+    echo "QUERY_STRING: $QUERY_STRING"
+    echo "Query: $query"
+  } >> "$DEBUG_FILE"
+fi
+
+if [[ -z $query ]]; then
+  echo 'Content-type: text/plain'
+  echo 'Status: 400'
+  echo
+  echo 'No query'
+  exit
+fi
+
+if [[ -z $format ]]; then
+  format=csv
+fi
+
+# The tricky part here is that we need to set Content-type and Status before we
+# can read psql return status. We catch the first line of psql's output and
+# check if it begins with an error
+if [[ $format = json ]]; then
+  psql -qAtc "select json_agg(t) from ($query) as t"
+elif [[ $format = csv ]]; then
+  if [[ -n $header ]]; then
+    header=header
+  fi
+  psql -qAc "\\copy ($query) to stdout with csv $header"
+fi 2>&1 |
+  {
+    IFS= read line
+    if [[ $line =~ ^ERROR: ]] || [[ $line =~ ^psql: ]]; then
+      echo 'Content-type: text/plain'
+      echo 'Status: 400'
+    elif [[ $format = json ]]; then
+      echo 'Content-type: application/json'
+    elif [[ $format = csv ]]; then
+      echo 'Content-type: text/csv'
+    else
+      echo 'Content-type: text/plain'
+    fi
+    echo
+    if [[ -n $line ]]; then
+      echo "$line"
+    fi
+    if [[ -n $DEBUG_FILE ]]; then
+      {
+        echo "Result: "
+        echo "$line"
+      } >> "$DEBUG_FILE"
+      tee -a "$DEBUG_FILE"
+    else
+      cat
+    fi
+  }

--- a/cgi-bin/tablecontent5.cgi
+++ b/cgi-bin/tablecontent5.cgi
@@ -1,5 +1,5 @@
 #!/bin/bash
 
+echo 'Content-type: text/plain'
+echo
 cat /tmp/table_file
-
-

--- a/docs/tooldaq.mkd
+++ b/docs/tooldaq.mkd
@@ -1,0 +1,650 @@
+# ToolDAQ API provided in tooldaq.js
+
+## Contents
+
+- [Generic HTTP request functions](#s-requests)
+  - [`request`](#request)
+  - [`requestText`](#requestText)
+  - [`requestJson`](#requestJson)
+  - [`requestCSV`](#requestCSV)
+  - [`requestHTML`](#requestHTML)
+- [Database quering](#s-database)
+  - [`dbJson`](#dbJson)
+  - [`dbTable`](#dbTable)
+  - [`dbPlot`](#dbPlot)
+- [Plotting functions](#s-plotting)
+  - [`getMonitoringPlot`](#getMonitoringPlot)
+  - [`makeMonitoringPlot`](#makeMonitoringPlot)
+  - [`getPlotlyPlot`](#getPlotlyPlot)
+  - [`makePlotlyPlot`](#makePlotlyPlot)
+- [Services functions](#s-services)
+  - [`getServices`](#getServices)
+  - [`getService`](#getService)
+  - [`sendCommand`](#sendCommand)
+  - [`getControls`](#getControls)
+  - [`makeControls`](#makeControls)
+- [Miscellaneous](#s-misc)
+  - [`makeTable`](#makeTable)
+
+<a name='s-requests'></a>
+## Generic HTTP request functions
+
+<a name='request'></a>
+### request
+
+```javascript
+request(url, args, options) -> Promise -> Response
+```
+Sends an HTTP request to `url` and returns a [`Promise`][Promise] to return a
+[`Response`][Response] object. This is a low-level function, see below for
+functions that make a request and process the [`Response`][Response].
+
+* `url` can be either
+  - a string with the URL to make a request to. The URL may be relative to the
+    base URL, [`baseURI`][baseURI].
+  - a [`URL`][URL] object.
+  - a [`Request`][Request] object.
+* `args` is an object specifying URL search parameters. Each key-value pair from
+  its enumerable properties is [%-encoded][%-encoding] and appended as
+  `?key1=value1&key2=value2` to `url` &mdash; literally if `url` is a string or
+  a [`Request`][Request], or through [`URLSearchParams`][URLSearchParams] if
+  `url` is a [`URL`][URL]. Existing `url` search parameters, if any, are
+  preserved in all cases.
+* `options` can be either:
+  - `null` or `undefined`. In this case the request type is GET.
+  - whatever is appropriate as a
+    [`body`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#setting_a_body)
+    in a [`RequestInit`][RequestInit] object.  In this case the request type is
+    POST and `options` provide the POST body.  An empty string can be used to
+    make a POST request with no data.
+  - any other object is passed to the underlying [`fetch`][fetch] function
+    unmodified. It should suit the [`RequestInit`][RequestInit] description.
+
+If the response status is not in the range 200&dash;299, a `RequestError`
+exception is thrown. `RequestError` is a derivative of [`Error`][Error] that
+provides a property `response` that holds the response that triggered the error.
+
+Examples:
+
+```javascript
+// fetch file contents
+await request('logs/Example_log').then(response => response.text());
+
+// GET /cgi-bin/db-query.cgi?query=select%20now()&format=json
+await request(
+  '/cgi-bin/db-query.cgi',
+  { query: 'select now()', format: 'json' }
+).then(response => response.json());
+
+// POST /cgi-bin/command.cgi?ip=172.18.0.2&port=24011
+await request(
+  '/cgi-bin/command.cgi',
+  { ip: '172.18.0.2', port: 24011 },
+  '? JSON' // POST body
+).then(response => response.text());
+
+// Returns the error message
+await request('/cgi-bin/db-query.cgi', { query: 'invalid sql' })
+      .catch(e => e.response.text())
+
+```
+
+<a name='requestText'></a>
+### requestText
+
+```javascript
+requestText(url, args, options) -> Promise -> string
+```
+Sends an HTTP request to `url` and returns a [`Promise`][Promise] to return a
+string with the response text.
+
+This is a convenience wrapper of
+```javascript
+request(url, args, options).then(response => response.text())
+```
+See [`request`](#request) for the description of the function parameters.
+
+<a name='requestJson'></a>
+### requestJson
+
+```javascript
+requestJson(url, args, options) -> Promise -> Object
+```
+Sends an HTTP request to `url`. The server is expected to return a string with a
+serialized JSON object. The function returns a [`Promise`][Promise] to return an
+`Object` deserialized from the server response.
+
+This is a convenience wrapper of
+```javascript
+request(url, args, options).then(response => response.json())
+```
+See [`request`](#request) for the description of the function parameters.
+
+<a name='requestCSV'></a>
+### requestCSV
+
+```javascript
+requestCSV(url, args, options) -> Promise -> [ [ ... ] ... ]
+```
+Sends an HTTP request to `url`. The server is expected to return a
+[comma-separated values file](https://en.wikipedia.org/wiki/Comma-separated_values).
+The file format should follow [RFC 4180](https://datatracker.ietf.org/doc/html/rfc4180),
+except that only single-byte line terminators are currently supported (LF rather
+than CRLF). The file is parsed into an [`Array`][Array] of `Array`.
+
+See [`request`](#request) for the description of the function parameters.
+
+In the case when an invalid CSV data is returned, the function throws a
+`CSVParseError` which is a derivative of [`Error`][Error].
+
+<a name='requestHTML'></a>
+### requestHTML
+
+```javascript
+requestHTML(url, mimeType)                -> Promise -> HTMLDocument
+requestHTML(url, args, options, mimeType) -> Promise -> HTMLDocument
+```
+Sends an HTTP request to `url`. The server is expected to return an HTML or an
+XML document which is then parsed to a DOM tree. `mimeType` is an optional
+argument that should be a string describing the type of the content, see
+[`DOMParser.parseFromString`][DOMParser.parseFromString]. If not provided, MIME
+type is extracted from Content-type of the server response header.
+
+See [`request`](#request) for the description of `args` and `options`.
+
+<a name='s-database'></a>
+## Database quering
+
+<a name='dbJson'></a>
+### dbJson
+
+```javascript
+dbJson(query) -> Promise -> [ { column: value, ... } ... ]
+```
+Sends `query` to the database and returns an array of objects, each object
+representing a row in the reply. Object keys are column names as provided in the
+query. If the query results in multiple columns with the same name, all columns
+except one will be lost from the output.
+
+`query` is a string with an SQL query. Parameters interpolation and string
+escaping are currently not supported.
+
+In case of a database error, the function throws a `DBError` which is a
+derivative of [`Error`][Error].
+
+<a name='dbTable'></a>
+### dbTable
+
+```javascript
+dbTable(query, header) -> Promise -> [ [ ... ] ... ]
+```
+Sends `query` to the database and returns an array of array, each inner array
+representing a row in the reply. If `header` is [truthy][truthy], the first row
+will contain column names as provided in the query.
+
+`query` is a string with an SQL query. Parameters interpolation and string
+escaping are currently not supported.
+
+In case of a database error, the function throws a `DBError` which is a
+derivative of [`Error`][Error].
+
+<a name='dbPlot'></a>
+### dbPlot
+
+```javascript
+dbPlot(query, template) -> Promise -> [ { name, x, y } ... ]
+```
+Sends `query` to the database and returns an array of objects suitable as the
+`data` argument to [Plotly][].[newPlot][Plotly.newPlot] function
+([traces][Plotly reference] in Plotly's lingua). The query is expected to result
+in two or more columns of numbers, timestamps, or whatever Plotly can use as a
+variable. The first column is interpreted as the plot x coordinate. For each
+other column an object is created with the following properties defined:
+
+- `name`: trace name that appears in the legend &mdash; the name of the column as
+  provided in the query.
+- `x`: an array of x coordinates &mdash; values of column 0.
+- `y`: an array of y coordinates &mdash; values of the column.
+
+In addition to that, `template` can be used to set default values for all
+returned traces. `template` should be an object (possibly `null` or
+`undefined`); each enumerable property of `template` is copied to each trace.
+
+`query` is a string with an SQL query. Parameters interpolation and string
+escaping are currently not supported.
+
+In case of a database error, the function throws a `DBError` which is a
+derivative of [`Error`][Error].
+
+Example:
+```javascript
+// Retreive traces for a couple of columns from the monitoring table; see however getMonitoringPlot function below
+let plot = dbPlot(
+  "select time, data->'temp_1' as \"temperature 1\", data->'temp_2' as \"temperature 2\" from monitoring where device = 'Example'
+);
+
+// Assuming Plotly is loaded and a <div id='test-div'></div> exists
+Plotly.newPlot('test-div', plot);
+```
+
+<a name='s-plotting'></a>
+## Plotting functions
+
+See also [dbPlot](#dbPlot).
+
+<a name='getMonitoringPlot'></a>
+### getMonitoringPlot
+
+```javascript
+getMonitoringPlot(device, options) -> Promise -> [ { name, x, y } ... ]
+```
+Retrieves monitoring data for `device` as an array of objects suitable as the
+`data` argument to [Plotly][].[newPlot][Plotly.newPlot] function
+([traces][Plotly reference]). Here `device` is a string with the name of the
+device. `options` can be null in which case all monitoring data is returned
+(which can be very large!), or an object with the following properties:
+- `columns`:  which columns to plot (see below).
+- `template`: default values for the traces.
+- `from`:     plot data newer than that.
+- `to`:       plot data older than that.
+
+`options.columns` can be
+
+- `null` or `undefined`: traces are returned for all columns, sorted by name.
+- a string: a trace for this column only is returned.
+- a regular expression: traces for all columns with names matching the regular
+  expression are returned
+- a function that takes a column name and returns `null`, a boolean or a string.
+  Plots are created only columns for which the function has returned `true` or a
+  string. If the function has returned a string, than this string is used as the
+  name of the trace.
+- an array of any of the above. A trace is created for a given column if its
+  name passes any of the tests in the array. An array element can also be an
+  array composed of two elements. The first element is used to test the column
+  name, the second element is used to compute the trace name as follows:
+  - if the first element is a string, the second element is the name of the
+    trace
+  - if the first element is a regular expression, both elements are used as an
+    argument to [`String.replace`][String.replace] called on the column name.
+  - if the first element is a function, the second element is the name of the
+    trace if the function returns `true`.
+
+All other kinds of values in `options.columns` result in an error.
+
+`options.template` is used to set common default values for all traces. Its
+enumerated properties are copied into each trace.
+
+`options.from` and `options.to` can be a [`Date`][Date] object or a string
+encoding a timestamp in whatever format is appropriate for PostgreSQL
+[timestamp with time zone][Postgresql.timestamp] data type.
+
+Examples:
+```javascript
+// Get traces for all monitoring data for device 'Example'.
+// Returns traces 'current_1', 'current_2', 'current_3', 'power_on', 'temp_1',
+'temp_2', 'temp_3', 'voltage_1', 'voltage_2', 'voltage_3'
+await getMonitoringPlot('Example');
+
+// Only 'power_on'
+await getMonitoringPlot('Example', { columns: 'power_on' });
+
+// All voltages from 01 November 2024
+await getMonitoringPlot('Example', { columns: /voltage/, from: 'Nov 1, 2024' });
+
+// Get all temperatures for the last 30 minutes and give the traces a less cryptic name
+await getMonitoringPlot(
+  'Example',
+  { 
+    columns: [ [ /temp_(\d+)/, 'temperature $1' ] ],
+    from: new Date(Date.now() - 30 * 60 * 60 * 1000)
+  }
+);
+
+// A contrived example showing how to use functions; same can be achieved with
+// regular expressions.
+// Get currents and power on status for the specified time interval. Plot as
+// lines (makeMonitoringPlot uses this template by default).
+await getMonitoringPlot(
+  'Example',
+  {
+    columns: [
+      column => /current/.test(column) && column.replace(/_/, ' '),
+      [ column => /power/.test(column), 'power' ]
+    ],
+    from: '2024-11-12 19:01',
+    to:   '2024-11-12 19:05',
+    template: { mode: 'lines' }
+  }
+);
+```
+
+<a name='makeMonitoringPlot'></a>
+### makeMonitoringPlot
+
+```javascript
+makeMonitoringPlot(div, device, option, layout) -> Promise -> div
+```
+Plots monitoring data for `device`. Calls
+[`getMonitoringPlot`](#getMonitoringPlot) passing it `device` and `option`
+arguments and then uses its result to call [Plotly][].[newPlot][Plotly.newPlot]
+function to build a plot on top of `div`.
+
+- `div` can be:
+  - `null` or `undefined` in which case a new &lt;div&gt; is constructed but is
+    not inserted in the `document`.
+  - `string` with an `id` of a &lt;div&gt; element already present on the page.
+  - an [`HTMLDivElement`][HTMLDivElement].
+- `device`: a string with the device name.
+- `option`: controls which data will be plot. See
+  [`getMonitoringPlot`](#getMonitoringPlot).
+- `layout`: controls the plot appearance. See the last argument to
+  [`Plotly.newPlot`][Plotly.newPlot].
+
+Returns `div` unless it is null, or a new &lt;div&gt; otherwise.
+
+Example:
+
+```javascript
+// Assuming a <div id='test-div'></div> exists on the page
+makeMonitoringPlot(
+  'test-div',
+  'Example',
+  { columns: /voltage/ },
+  { title: 'Voltages' }
+);
+```
+
+<a name='getPlotlyPlot'></a>
+### getPlotlyPlot
+
+```javascript
+getPlotlyPlot(name, version) -> Promise -> { name, time, version, traces, layout }
+```
+Retrieves a [Plotly][] plot stored in the database.
+- `name`: plot name
+- `version`: plot version (a number). If `null` or `undefined`, the latest in
+  time plot is returned.
+
+Returns an object with the following properties:
+- `name`: plot name.
+- `time`: the time when the plot was created.
+- `version`: plot version.
+- `traces`, `layout`: whatever JSON data was provided during the plot creation.
+  They are supposed to be the corresponding arguments to
+  [`Plotly.newPlot`][Plotly.newPlot] function.
+
+<a name='makePlotlyPlot'></a>
+### makePlotlyPlot
+
+```javascript
+makePlotlyPlot(div, name, version) -> Promise -> div
+```
+
+Plots a [Plotly][] plot stored in the database. Calls
+[`getPlotlyPlot`](#getPlotlyPlot) passing `name` and `version` and the uses its
+result to call [`Plotly.newPlot`][Plotly.newPlot] function to build a plot on
+top of `div`.
+
+`div` can be:
+- `null` or `undefined` in which case a new &lt;div&gt; is constructed but not
+  inserted in the `document`.
+- `string` with an `id` of a &lt;div&gt; element already present on the page.
+- an [`HTMLDivElement`][HTMLDivElement].
+
+Returns `div` unless it is null, or a new &lt;div&gt; otherwise.
+
+<a name='s-services'></a>
+## Services functions
+
+<a name='getServices'></a>
+### getServices
+
+```javascript
+getServices(filter) -> Promise -> [ { id, ip, port, name, status }, ... ]
+```
+
+Returns an array of services matching the filter. The latter can be
+- `null` or `undefined` &mdash; all services are returned.
+- a string &mdash; services with this name are returned (presumably only one).
+- a regular expression &mdash; services with the name matching the expression
+  are returned.
+- a function that takes a service (an object with the structure shown above) and
+  returns a boolean &mdash; services for which the function returned a
+  [truthy][] are returned.
+
+<a name='getService'></a>
+### getService
+
+```javascript
+getService(name) -> Promise -> { id, ip, port, name, status }
+```
+Returns a service matching `name` which can be whatever
+[`getServices`](#getServices) can take as an argument. An error is thrown if
+more than one service matches `name`.
+
+<a name='sendCommand'></a>
+### sendCommand
+
+```javascript
+sendCommand(service, command, ...args) -> Promise -> string
+```
+Sends a command to a service and returns the service reply.
+
+- `service`: an object returned by `getService` or `getServices`, or anything
+  what they would accept as an argument.
+- `command`: command name.
+- `args`: command arguments. Currently this function sends a string with the
+  command and all arguments joined with spaces.
+
+Returns whatever the service has replied with.
+
+Example:
+```javascript
+await sendCommand('middleman_1', 'Status');
+```
+
+<a name='getControls'></a>
+### getControls
+
+```javascript
+getControls(service) -> Promise -> [ { name, type, value, ... }, ... ]
+```
+Queries a service for slow controls that it supports. `service` is whatever
+[`sendCommand`](#sendCommand) accepts as a service. Returns a description of
+controls:
+- `name`:  control name
+- `value`: current control value
+- `type`:  control type
+
+Following are control types that currently have been implemented and extra
+properties that will appear in the control object:
+- `INFO`
+  - no extra properties
+- `BUTTON`
+  - no extra properties
+- `OPTIONS`
+  - `options`: an array of values that this control can take
+- `VARIABLE`:
+  - `min`: minimal value this control can take
+  - `max`: maximal value this control can take
+  - `step`: an amount that this control can be varied with
+
+<a name='makeControls'></a>
+### makeControls
+
+```javascript
+makeControls(div, service) -> Promise -> div
+```
+Fills a &lt;div&gt; with slow controls for a service.
+
+`div` can be:
+- `null` or `undefined` in which case a new &lt;div&gt; is constructed but not
+  inserted in the `document`.
+- `string` with an `id` of a &lt;div&gt; element already present on the page.
+- an [`HTMLDivElement`][HTMLDivElement]
+
+`service` is whatever [`sendCommand`](#sendCommand) accepts as a service.
+
+Returns `div` unless it is null, or a new &lt;div&gt; otherwise.
+
+An updating function is associated with the `div` which is called periodically
+to update the controls state. It is not destroyed if the `div` is released. To
+avoid memory leak and useless CPU burn, remember to call
+`div.dataset.controls_stop()` to stop and release the updating function when the
+`div` is not needed anymore.
+
+<a name='s-misc'></a>
+## Miscellaneous
+
+<a name='makeTable'></a>
+### makeTable
+
+```javascript
+makeTable(table, data, header, filter) -> table
+```
+Fills an HTML table with data.
+
+- `table` can be:
+  - `null` or `undefined` in which case a new &lt;table&gt; is constructed but
+    not inserted in the `document`.
+  - `string` with an `id` of a &lt;table&gt; element already present on the
+    page.
+  - an [`HTMLTableElement`][HTMLTableElement]
+- `data` can be:
+  - `null` or `undefined` representing an empty table.
+  - an array of objects: `[ { column: value, ... }, ... ]`
+  - an array of arrays:  `[ [ value0, value1, ... ], ... ]`
+- `header` is used provide the header to the table and also to select what
+  columns to take from `data` and in what order, see below.
+- `filter` is an optional function that takes a row and the row index and
+  returns an object that should be included in the table. `null` values are
+  skipped. `(row, index) => row` is used by default.
+
+If `data` is an array of objects, then it is assumed that all objects have
+a (mostly) common set of (enumerated) properties, and these properties are
+treated as columns. The set of columns is extracted from the first object, but
+it can be overriden with some settings of `header`. Following `header` values
+are supported:
+- `null` or `undefined`: no table header is provided. The set of columns is
+  extracted from the first row. If some object in the rest of the table has a
+  different set of properties, mismatched properties won't be present in the
+  table. The columns are sorted by name.
+- `true`: same as above, but the properties names are inserted as a header
+  (&lt;thead&gt;) in the table.
+- an array, e.g., `[ 'a', 'b', 'c' ]`: use properties "a", "b", "c" to compose a
+  table with three columns; insert a header with these column names in the
+  table. The header can be omitted by inserting a `false` at the beginning of
+  the array, e.g., `[ false, 'a', 'b', 'c' ]`. Instead of a string with the
+  column name, you can also use an array of two elements: the property name and
+  the column name to appear in the header, e.g., `[ 'a', [ 'b', 'Fancy name for
+  b' ], 'c' ]`.
+- a function. This function is called with `Object.keys(data[0])` as the only
+  argument, and it should return one of the values above, i.e., `null`,
+  `undefined`, `true`, or an array. The value is processed accordingly.
+
+If `data` is an array of arrays, the number of columns is defined by the first
+row. Depending on the value of `header`, the first row may be treated as
+containing column names &mdash; this is a common approach for CSV files. Following
+`header` values are supported:
+- `null` or `undefined`: no table header is provided. The number of columns is
+  determined by the first row.
+- `true`: the first row contains column names which are used for the header.
+- `false`: skip the first row, no header is inserted in the table.
+- array of strings or nulls, e.g., `[ 'a', 'b', null, 'c' ]`: strings provide
+  column names, null columns are skipped.
+- array of numbers, e.g., `[ 3, 2 ]`: use columns in that order, no header is
+  inserted.
+- array of `true` followed by numbers, e.g., `[ true, 3, 2 ]`: use `data[0]` as
+  the header, use specified columns only.
+- array of arrays with numbers as first elements, e.g., `[ [ 3, 'A' ], [ 2, 'B'
+  ] ]`: numbers specify column indices, strings specify column names.
+- array of `true` followed by strings, e.g., `[ true, 'a', 'b', 'c' ]`:
+  `data[0]` contains column names, strings specify which columns are used and in
+  what order.
+- array of `false` followed by strings, e.g., `[ false, 'a', 'b', 'c' ]`: same
+  as above, but no header is inserted in the table.
+- array of `true` followed by numbers or arrays with numbers as first elements,
+  e.g., `[ true, [ 3, 'A' ], 1, 2 ]`: `data[0]` contains column names, numbers
+  specify which columns are used, strings override column names that will be
+  shown in the header.
+- array of `true` followed by strings or arrays with strings as first elements,
+  e.g., `[ true, 'a', [ 'b', 'B' ], 'c' ]`: `data[0]` contains column names.
+  First elements and bare strings specify which columns to use, second elements
+  override column names that will be shown in the header.
+- a function. This function is called with `data[0]` as the only argument, and
+  it should return one of the values above. The value is processed accordingly.
+
+Examples:
+
+```javascript
+// Returns
+// <table>
+//   <tbody>
+//     <tr><td>a0</td><td>b0</td></tr>
+//     <tr><td>a1</td><td>b1</td></tr>
+//   </tbody>
+// </table>
+makeTable(null, [ { a: 'a0', b: 'b0' }, { a: 'a1', b: 'b1' } ]);
+makeTable(null, [ [ 'a0', 'b0' ], [ 'a1', 'b1' ] ]);
+
+// Returns
+// <table>
+//   <thead>
+//     <tr><th>a</th><th>b</th></tr>
+//   </thead>
+//   <tbody>
+//     <tr><td>a0</td><td>b0</td></tr>
+//     <tr><td>a1</td><td>b1</td></tr>
+//   </tbody>
+// </table>
+makeTable(null, [ { a: 'a0', b: 'b0' }, { a: 'a1', b: 'b1' } ], true);
+makeTable(null, [ [ 'a', 'b' ], [ 'a0', 'b0' ], [ 'a1', 'b1' ] ], true);
+
+// Returns
+// <table>
+//   <thead>
+//     <tr><th>B</th><th>a</th></tr>
+//   </thead>
+//   <tbody>
+//     <tr><td>b0</td><td>a0</td></tr>
+//     <tr><td>b1</td><td>a1</td></tr>
+//   </tbody>
+// </table>
+makeTable(
+  null,
+  [ { a: 'a0', b: 'b0' }, { a: 'a1', b: 'b1' } ],
+  [ [ 'b', 'B' ], 'a' ]
+);
+makeTable(
+  null,
+  [ [ 'a0', 'b0' ], [ 'a1', 'b1' ] ],
+  [ [ 1, 'B' ], 0 ]
+);
+makeTable(
+  null,
+  [ [ 'a', 'b' ], [ 'a0', 'b0' ], [ 'a1', 'b1' ] ],
+  [ true, [ 'b', 'B' ], 'a' ]
+);
+```
+
+[truthy]:           https://developer.mozilla.org/en-US/docs/Glossary/Truthy
+[Array]:            https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
+[baseURI]:          https://developer.mozilla.org/en-US/docs/Web/API/Node/baseURI
+[%-encoding]:       https://en.wikipedia.org/wiki/Percent-encoding
+[Error]:            https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
+[fetch]:            https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch
+[Promise]:          https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[Request]:          https://developer.mozilla.org/en-US/docs/Web/API/Request
+[RequestInit]:      https://developer.mozilla.org/en-US/docs/Web/API/RequestInit
+[Response]:         https://developer.mozilla.org/en-US/docs/Web/API/Response
+[URL]:              https://developer.mozilla.org/en-US/docs/Web/API/URL
+[URLSearchParams]:  https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
+[Plotly]:           https://plotly.com/javascript/
+[Plotly.newPlot]:   https://plotly.com/javascript/plotlyjs-function-reference/#plotlynewplot
+[DOMParser.parseFromString]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String
+[Plotly reference]: https://plotly.com/javascript/reference/
+[String.replace]:   https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace
+[Date]:             https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date
+[Postgresql.timestamp]: https://www.postgresql.org/docs/current/datatype-datetime.html
+[HTMLDivElement]:   https://developer.mozilla.org/en-US/docs/Web/API/HTMLDivElement
+[HTMLTableElement]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLTableElement

--- a/html
+++ b/html
@@ -1,1 +1,1 @@
-html-Detector
+html-StandAlone

--- a/html-Common/includes/tooldaq.js
+++ b/html-Common/includes/tooldaq.js
@@ -1,0 +1,944 @@
+// request(url, args, options)     -> Response
+// requestText(url, args, options) -> string
+// requestJson(url, args, options) -> JSON
+// requestCSV(url, args, options)  -> Array of Array
+//
+// dbJson(query)           -> JSON [ { column: value } ]
+// dbTable(query, header)  -> Array of Array, first row may be column names
+// dbPlot(query, template) -> Array of plots (Plotly objects) for each column
+//
+// getMonitoringPlot(device, options) -> Array of plots extracted from the monitoring table
+// makeMonitoringPlot(div, device, options, layout) -> div - cals getMonitoringPlot and fills the div
+//
+// getPlotlyPlot(name, version) -> plot from plotlyplots table
+// makePlotlyPlot(div, name, version) -> div - calls getPlotlyPlot and fills the div
+//
+// makeTable(table, data, header, filter) -> table - builds and HTML table from data
+//
+// getServices(filter) -> [ { id, ip, port, name, status } ]
+// getService(name)    ->   { id, ip, port, name, status }
+//
+// sendCommand(service, command, ...args) -> string reply
+//
+// getControls(service) -> sendCommand(service, '?', 'JSON')
+// makeControls(div, service) -> <div> with controls
+
+'use strict';
+
+class RequestError extends Error {
+  constructor(message, response) {
+    super(message);
+    this.response = response;
+  }
+};
+
+class DBError extends Error {};
+
+class CSVParseError extends Error {};
+
+async function parseCSV(stream) {
+  let result = [];
+  let row    = [];
+  let cell   = [];
+
+  let decoder = new TextDecoder();
+
+  let start   = true;
+  let quoted  = false;
+  let escaped = false;
+
+  function commit_cell(and_row) {
+    row.push(decoder.decode(Uint8Array.from(cell)));
+    cell.length = 0;
+    if (and_row) {
+      result.push(row);
+      row = [];
+    };
+    start   = true;
+    quoted  = false;
+    escaped = false;
+  };
+
+  function fail(message) {
+    commit_cell(true);
+    if (result.length > 0)
+      row = result[result.length - 1];
+    if ((row.length == 0 || row.length == 1 && row[0] == '')
+        && result.length > 1)
+      row = result[result.length - 2];
+    if (row.length > 1 || row.length == 1 && row[0] != '')
+      message += '; last row was (unquoted) `' + row.join(',') + "'";
+    throw new CSVParseError(message);
+  };
+
+  for await (let chunk of stream)
+    for (let byte of chunk) {
+      if (byte == 0x22 /* " */) {
+        if (start) {
+          start  = false;
+          quoted = true;
+          continue;
+        };
+
+        if (quoted) {
+          if (escaped) {
+            cell.push(byte);
+            escaped = false;
+          } else
+            escaped = true;
+          continue;
+        };
+
+        fail('Unexpected quote');
+      };
+      start = false;
+
+      switch (byte) {
+        case 0x2C: // ,
+          if (!quoted || escaped)
+            commit_cell(false);
+          else
+            cell.push(byte);
+          break;
+        case 0x0A: // \n
+          if (!quoted || escaped)
+            commit_cell(true);
+          else
+            cell.push(byte);
+          break;
+        default:
+          if (quoted && escaped)
+            fail(
+              'Unexpected byte 0x'
+              + byte.toString(16)
+              + " ('"
+              + String.fromCharCode(byte)
+              + "') between quote and delimiter"
+            );
+          cell.push(byte);
+      };
+    }
+
+  return result;
+};
+
+export function request(url, args, options) {
+  const encode_url
+    = url => url
+          +  (url.indexOf('?') >= 0 ? '&' : '?')
+          +  Object.entries(args).map(
+               ([ arg, value ]) => encodeURIComponent(arg)
+                                +  '='
+                                +  encodeURIComponent(value)
+             ).join('&');
+
+  if (args != null) {
+    if (typeof url == 'string')
+      url = encode_url(url);
+    else if (url instanceof URL) {
+      url = new URL(url); // avoid changing the argument
+      for (let [ arg, value ] of Object.entries(args))
+        url.searchParams.append(arg, value);
+    } else if (url instanceof Request) {
+      url = new Request(encode_url(url.url), url);
+    } else
+      throw TypeError('request: invalid url type: ' + url);
+  };
+
+  if (options
+      && (typeof(options) == 'string'
+          || Object.getPrototypeOf(options) !== Object.prototype))
+    options = { method: 'POST', body: options };
+
+  return fetch(url, options).then(
+    function (response) {
+      if (!response.ok)
+        throw new RequestError(
+          `Request ${response.url} failed with status ${response.status} ${response.statusText}`,
+          response
+        );
+      return response;
+    }
+  );
+};
+
+export function requestText(url, args, options) {
+  return request(url, args, options).then(response => response.text());
+};
+
+export function requestJson(url, args, options) {
+  return request(url, args, options).then(response => response.json());
+};
+
+export function requestCSV(url, args, options) {
+  return request(url, args, options).then(response => parseCSV(response.body));
+};
+
+export function requestHTML(url, args, options, mimeType) {
+  if (arguments.length == 2 && typeof args == 'string') {
+    mimeType = args;
+    args = null;
+  };
+
+  return request(url, args, options).then(
+    async function (response) {
+      let text = await response.text();
+      if (mimeType == null) {
+        mimeType = response.headers.get('Content-type').replace(/;.*/, '');
+      };
+      return new DOMParser().parseFromString(text, mimeType);
+    }
+  );
+};
+
+function db(query, format, header) {
+  let args = { query, format };
+  if (header) args.header = 1;
+  return request('/cgi-bin/db-query.cgi', args).catch(
+    async function (error) {
+      if (error instanceof RequestError && error.response.status == 400) {
+        let message = await error.response.text();
+        throw new DBError(`Bad query ${query}: ${message}`, { cause: error });
+      } else
+        throw error;
+    }
+  );
+};
+
+export function dbJson(query) {
+  return db(query, 'json').then(response => response.json());
+};
+
+export function dbTable(query, header) {
+  return db(query, 'csv', header).then(response => parseCSV(response.body));
+};
+
+export function dbPlot(query, template) {
+  return dbTable(query, true).then(
+    function (table) {
+      function column(index) {
+        let result = new Array(table.length - 1);
+        for (let i = 0; i < result.length; ++i) result[i] = table[i+1][index];
+        return result;
+      };
+
+      let x = column(0);
+      let plots = new Array(table[0].length - 1);
+      for (let i = 0; i < plots.length; ++i)
+        plots[i] = Object.assign(
+          { name: table[0][i+1], x: x, y: column(i+1) },
+          template
+        );
+
+      return plots;
+    }
+  );
+};
+
+export function getMonitoringPlot(device, options) {
+  if (typeof(device) != 'string' || device == '')
+    throw Error('getMonitoringPlot: device must be a non-empty string');
+
+  let columns  = options?.columns;
+  let template = options?.template;
+
+  function encodeDate(date) {
+    if (date instanceof Date)
+      return date.toISOString() + date.getTimezoneOffset();
+    return date;
+  };
+
+  if (options) {
+    var from = encodeDate(options.from);
+    var to   = encodeDate(options.to);
+  };
+
+  let query = `select time, data from monitoring where device = '${device}'`;
+  if (from != null)
+    query += ` and time >= '${from}'`;
+  if (to != null)
+    query += ` and time <= '${to}'`;
+  query += ' order by time';
+
+  if (columns != null) {
+    if (!(columns instanceof Array)) columns = [ columns ];
+    var fixed = [];
+    var tests = [];
+    for (let i = 0; i < columns.length; ++i) {
+      let column = columns[i];
+      let name;
+      if (column instanceof Array) {
+        name = column[1];
+        column = column[0];
+      };
+      if (typeof column == 'string')
+        fixed.push({ index: i, key: column, name: name ?? column });
+      else if (column instanceof RegExp)
+        tests.push({
+          index: i,
+          fn:    name == null
+                 ? c => column.test(c)
+                 : c => column.test(c) && c.replace(column, name)
+        });
+      else if (column instanceof Function)
+        tests.push({
+          index: i,
+          fn:    name == null ? column : c => column(c) && name
+        });
+      else
+        throw Error('Invalid column specification: ' + columns[i].toString());
+    };
+  };
+
+  return dbTable(query).then(
+    function (table) {
+      let y = {};
+      if (columns == null) {
+        for (let i = 0; i < table.length; ++i) {
+          let row = JSON.parse(table[i][1]);
+          for (let column in row) {
+            y[column] ??= {
+              index: 0,
+              name:  column,
+              data:  new Array(table.length)
+            };
+            y[column].data[i] = row[column];
+          };
+        };
+      } else {
+        for (let column of fixed)
+          y[column] = {
+            index: column.index,
+            name:  column.name,
+            data:  new Array(table.length)
+          };
+        for (let i = 0; i < table.length; ++i) {
+          let row = JSON.parse(table[i][1]);
+          for (let column in row) {
+            let exists = column in y;
+            if (!exists)
+              for (let test of tests) {
+                let name = test.fn(column);
+                if (name != null && name != false) {
+                  exists = true;
+                  y[column] = {
+                    index: test.index,
+                    name:  name === true ? column : name,
+                    data:  new Array(table.length)
+                  };
+                  break;
+                };
+              };
+            if (exists) y[column].data[i] = row[column];
+          };
+        };
+      };
+
+      let x = table.map(row => new Date(row[0].replace(/[+-]\d{2}$/, 'Z$&')));
+
+      return Object.values(y).sort(
+        function (a, b) {
+          let i = a.index - b.index;
+          if (i) return i;
+          if (a.name < b.name) return -1;
+          if (a.name > b.name) return  1;
+          return 0;
+        }
+      ).map(
+        y => Object.assign({ name: y.name, x: x, y: y.data }, template)
+      );
+    }
+  );
+}
+
+export function makeMonitoringPlot(div, device, options, layout) {
+  options ??= {};
+  options.template ??= { mode: 'lines' };
+  getMonitoringPlot(device, options).then(
+    function (plots) {
+      if (div == null) div = document.createElement('div');
+      if (!plots) Plotly.purge(div);
+      Plotly.newPlot(div, plots, layout);
+      return div;
+    }
+  );
+};
+
+export function getPlotlyPlot(name, version) {
+  if (typeof(name) != 'string' || name == '')
+    throw Error('dbPlotlyPlot: name must be a non-empty string');
+
+  if (version == null)
+    version = 'order by time desc limit 1';
+  else if (typeof(version) == 'number')
+    version = `and version = ${version}`
+
+  return dbJson(
+    `select * from plotlyplots where name = '${name}' ${version}`
+  ).then(
+    function (table) {
+      let plot = table[0];
+      plot.time = new Date(plot.time);
+      return plot;
+    }
+  );
+};
+
+export function makePlotlyPlot(div, name, version) {
+  getPlotlyPlot(name, version).then(
+    function (plot) {
+      if (div == null) div = document.createElement('div');
+      if (!plot) Plotly.purge(div);
+      Plotly.newPlot(div, plot.traces, plot.layout);
+      return div;
+    }
+  );
+};
+
+// header:
+//   data[0] is an array:
+//     null or undefined --- no header, use all columns
+//     true:
+//       data[0] is the header, use all columns
+//     false:
+//       skip data[0], use all columns
+//     Function:
+//       (data[0]) => header
+//       header should be an array that will be processed as below.
+//     Array:
+//       [ 'a', 'b', null, 'c' ]
+//       (array of strings or nulls):
+//         strings provide column names, null columns are skipped
+//       [ 3, 2 ]
+//       (array of numbers):
+//         use specified columns in this order
+//       [ [ 3, 'A' ], [ 2, 'B' ] ]
+//       (array of arrays with numbers as first elements):
+//         numbers specify columns indices, strings specify column names
+//       [ true, 'a', 'b', 'c' ]
+//       (true followed by strings):
+//         data[0] is assumed to contain header names, strings specify which
+//         columns are used and in what order.
+//       [ false, 'a', 'b', 'c' ]
+//       (false followed by strings):
+//         same as above, but do not insert the header in the table
+//       [ true, 3, 2 ]
+//       (true followed by numbers):
+//         data[0] is the header, use specified columns in this order
+//       [ true, [ 3, 'A' ], 1, [ 2, 'B' ] ]
+//       (true followed by array of numbers or arrays with numbers as first elements):
+//         data[0] is the header, numbers specify columns indices, strings
+//         specify column names
+//       [ true, 'a', [ 'b', 'B' ], [ 'c', 'C' ] ]
+//       (array of strings or arrays with strings as first elements):
+//         data[0] is assumed to contain header names. First elements specify
+//         which columns are used and in what order, second elements map column
+//         names to titles.
+//   data[0] is an object:
+//     null or undefined --- no header, use all columns sorted by name
+//     true:
+//       add header, use all columns sorted by name
+//     Function:
+//       (Object.keys(data[0])) => header
+//       header should be an array that will be processed as below.
+//     Array:
+//       [ 'a', 'b', [ 'c', 'C' ] ]
+//       (array of strings or arrays with strings as first elements):
+//         specifies columns to be used and mapping to column titles
+//       [ false, 'a', 'b', 'c' ]
+//       (false followed by strings)
+//         specifies which columns to use, but the header won't be inserted in
+//         the table
+// filter:
+//   (row, index) => new_row
+//   index is the row index in the table (can be used to reset filter state)
+//   row can be modified and returned
+//   If new_row == null, the row is skipped
+//   row with index 0 is passed through filter before possibly treating it as a
+//   header. If filter filters out this row, the table will have no columns.
+export function makeTable(table, data, header, filter = (row, index) => row) {
+  if (table == null)
+    table = document.createElement('table');
+  else if (typeof table == 'string') {
+    let t = document.getElementById(table);
+    if (t == null)
+      throw Error(`No DOM element with id '${table}' exists on the page`);
+    table = t;
+  };
+
+  if (!table) table = document.createElement('table');
+
+  table.innerHTML = '';
+
+  function bad_header() {
+    throw Error('makeTable: invalid header specification: ' + JSON.stringify(header));
+  };
+
+  let index = 0;
+  let row;
+  if (data && data.length) row = filter(data[index++], 0);
+
+  let columns;
+  if (row == null) {
+    // See if we can add a header to an empty table. It is possible only if the
+    // caller specified both column names and their indices.
+    if (!(header instanceof Array) || !header.length) return table;
+    let titles = [];
+    let i = 0;
+    if (header[i] === true) ++i;
+    for (; i < header.length; ++i) {
+      let h = header[i];
+      if (h instanceof Array) {
+        if (typeof h[0] == 'string')
+          titles.push(h[1]);
+        else
+          return table;
+      } else if (h == null) {
+        continue;
+      } else if (typeof h == 'string') {
+        titles.push(h);
+      } else
+        return table;
+    };
+    header = titles;
+  } else if (row instanceof Array) {
+    if (header instanceof Function)
+      header = header(row);
+
+    if (header instanceof Array) {
+      if (!header.length) return table; // no columns
+
+      // Check header specification. It may begin with true
+      let use_row     = false;
+      let emit_header = true;
+      let hstart      = 0;
+      if (header[0] === true || header[0] === false) {
+        use_row     = true;
+        emit_header = header[0];
+        ++hstart;
+      };
+      // Followed by either (strings or nulls) or numbers or arrays where all
+      // first elements are a string or a number
+      let strings = false;
+      let numbers = false;
+      let renames = 0;
+      for (let i = hstart; i < header.length; ++i) {
+        if (header[i] == null || typeof header[i] == 'string')
+          strings = true;
+        else if (typeof header[i] == 'number')
+          numbers = true;
+        else if (header[i] instanceof Array) {
+          ++renames;
+          if (typeof header[i][0] == 'string')
+            strings = true;
+          else if (typeof header[i][1] == 'number')
+            numbers = true;
+        };
+      };
+      if (strings == numbers
+          // [ [ 3, 'A' ], 1 ] or [ [ 'a', 'A' ], 'b' ] are invalid unless use_row
+          || !use_row && renames && (strings || renames != header.length))
+        bad_header();
+
+      let titles  = [];
+      columns = [];
+      if (use_row) {
+        if (strings) {
+          // [ 'a', [ 'b', 'B' ], [ 'c', 'C' ] ]
+          let map = {};
+          for (let i = 0; i < row.length; ++i)
+            map[row[i]] = i;
+          for (let i = hstart; i < header.length; ++i) {
+            let h = header[i];
+            if (h instanceof Array) {
+              columns.push(map[h[0]]);
+              titles.push(h[1]);
+            } else {
+              columns.push(map[h]);
+              titles.push(h);
+            };
+          };
+        } else {
+          // [ 3, [ 2, 'B' ] ]
+          for (let i = hstart; i < header.length; ++i) {
+            let h = header[i];
+            if (h instanceof Array) {
+              columns.push(h[0]);
+              titles.push(h[1]);
+            } else {
+              columns.push(h);
+              titles.push(row[h]);
+            };
+          };
+        };
+        row = null;
+      } else if (strings) {
+        // [ 'a', 'b', null, 'c' ]
+        for (let i = 0; i < header.length; ++i)
+          if (header[i] != null) {
+            columns.push(i);
+            titles.push(header[i]);
+          };
+      } else {
+        // [ 3, [ 2, 'B' ] ]
+        for (let i = 0; i < header.length; ++i) {
+          let h = header[i];
+          if (h instanceof Array) {
+            columns.push(h[0]);
+            titles.push(h[1]);
+          } else
+            columns.push(h);
+        };
+      };
+      header = emit_header && titles.length ? titles : null;
+    } else {
+      columns = Array.from(row.keys());
+      if (header === true) {
+        header = row;
+        row    = null;
+      } else if (header === false) {
+        header = null;
+        row    = null;
+      } else if (header != null)
+        bad_header();
+    };
+  } else { // row is an object
+    if (header instanceof Function)
+      header = header(Object.keys(row));
+
+    if (header instanceof Array) {
+      if (!header.length) return table; // no columns
+
+      let emit_header = true;
+      let i = 0;
+      if (header[0] === false || header[0] === true) {
+        emit_header = header[0];
+        ++i;
+      };
+
+      // [ 'a', 'b', [ 'c', 'C' ] ]
+      columns = [];
+      let titles = [];
+      for (; i < header.length; ++i ) {
+        let h = header[i];
+        if (h instanceof Array) {
+          columns.push(h[0]);
+          titles.push(h[1]);
+        } else {
+          columns.push(h);
+          titles.push(h);
+        };
+      };
+      header = emit_header ? titles : null;
+    } else {
+      columns = Object.keys(row).sort();
+      if (header === true)
+        header = columns;
+      else if (header != null)
+        bad_header();
+    };
+  };
+
+  if (header) {
+    let tr = table.createTHead().insertRow();
+    for (let h of header) {
+      let th = document.createElement('th');
+      th.textContent = h;
+      tr.append(th);
+    };
+  };
+
+  if (!data || index >= data.length) return table;
+
+  let tbody = table.createTBody();
+  function add_row(row) {
+    let tr = tbody.insertRow();
+    for (let column of columns) {
+      let cell = row[column];
+      if (cell instanceof Object) cell = JSON.stringify(cell);
+      tr.insertCell().textContent = cell;
+    };
+  };
+
+  if (row != null) add_row(row);
+  for (; index < data.length; ++index) {
+    let row = filter(data[index], index);
+    if (row != null) add_row(row);
+  };
+
+  return table;
+};
+
+
+export function getServices(filter) {
+  if (filter == null)
+    filter = service => true;
+  else if (typeof filter == 'string') {
+    let name = filter;
+    filter = row => row.name == name;
+  } else if (filter instanceof RegExp) {
+    let regex = filter;
+    filter = row => regex.test(row.name);
+  } else if (!(filter instanceof Function))
+    throw Error(
+      'getServices: invalid filter: '
+      + (filter instanceof Object ? JSON.stringify(filter) : filter)
+    );
+
+  return requestCSV('/services.txt').then(
+    function (table) {
+      let keys = [ 'id', 'ip', 'port', 'name', 'status' ];
+      let out = 0;
+      for (let i = 0; i < table.length; ++i) {
+        let row = table[i];
+        let service = {};
+        for (let j = 0; j < keys.length; ++j) service[keys[j]] = row[j];
+        if (filter(service)) table[out++] = service;
+      };
+      table.length = out;
+      return table;
+    }
+  );
+};
+
+export function getService(name) {
+  return getServices(name).then(
+    function (services) {
+      if (services.length > 1)
+        throw Error(
+          `getService(${name}): multiple services found (${services.length})`
+        );
+      if (services.length == 0) return null;
+      return services[0];
+    }
+  );
+};
+
+export function sendCommand(service, command, ...args) {
+  if (service == null) throw Error('sendCommand: service is null');
+
+  if (!(service instanceof Object)
+      || service instanceof Function
+      || service instanceof RegExp)
+    return getService(service).then(
+      function (s) {
+        if (s == null)
+          throw Error(`sendCommand: service ${service} not found`);
+        return sendCommand(s, command, ...args);
+      }
+    );
+
+  return requestText(
+    '/cgi-bin/command.cgi',
+    { ip: service.ip, port: service.port },
+    command + (args.length > 0 ? ' ' : '') + args.join(' ')
+  );
+};
+
+export function getControls(service) {
+  return sendCommand(service, '?', 'JSON').then(JSON.parse);
+};
+
+export function makeControls(div, service) {
+  if (service == null) return;
+
+  return getControls(service).then(
+    function (commands) {
+      function make(tag, className) {
+        let element = document.createElement(tag);
+        element.className = className;
+        return element;
+      };
+
+      function make_name(name) {
+        let span = make('span', 'control-name');
+        span.textContent = name + ': ';
+        return span;
+      };
+
+      if (div == null)
+        div = make('div', 'controls');
+      else if (typeof div == 'string') {
+        let d = document.getElementById(div);
+        if (d == null)
+          throw Error(`No DOM element with id '${div}' exists on the page`);
+        div = d;
+      } else {
+        // If the div already has controls, stop the timer
+        let stop = div.dataset.controls_stop;
+        if (stop != null) stop();
+        div.innerHTML = '';
+      };
+
+      let output = make('div', 'control-output');
+
+      async function send_command(command, ...args) {
+        output.textContent = await sendCommand(service, command, ...args);
+      };
+
+      let controls = {};
+      for (let command of commands) {
+        let row = make('div', 'control');
+        if (command.type == 'INFO') {
+          row.append(make_name(command.name));
+
+          let span = make('span', 'control');
+          span.textContent = command.value;
+          row.append(span);
+
+          controls[command.name] = cmd => span.textContent = cmd.value;
+        } else if (command.type == 'BUTTON') {
+          let button = make('button', 'control');
+          button.textContent = command.name;
+          button.addEventListener(
+            'click',
+            command.value
+            ? () => void send_command(command.name, command.value)
+            : () => void send_command(command.name)
+          );
+          row.append(button);
+          controls[command.name] = cmd => void(command.value = cmd.value);
+        } else if (command.type == 'OPTIONS') {
+          row.append(make_name(command.name));
+
+          let update = make('button', 'control-update');
+          update.textContent = 'Update';
+          update.disabled    = true;
+          update.addEventListener(
+            'click',
+            function () {
+              for (let input of row.childNodes)
+                if (input instanceof HTMLInputElement && input.checked) {
+                  send_command(command.name, input.value);
+                  command.value = input.value;
+                  update.disabled = true;
+                  return;
+                }
+            }
+          );
+
+          let inputs = {};
+          for (let option of command.options) {
+            let input = make('input', 'control');
+            input.type     = 'radio';
+            input.id       = command.name + '-' + option;
+            input.name     = command.name;
+            input.value    = option;
+            input.checked  = command.value == option;
+            input.onchange = () => void(update.disabled = input.value == command.value);
+            row.append(input);
+
+            let label = document.createElement('label');
+            label.htmlFor     = input.id;
+            label.textContent = option;
+            row.append(label);
+            inputs[option] = input;
+          };
+
+          row.append(update);
+
+          controls[command.name] = function (cmd) {
+            command.value = cmd.value;
+            if (update.disabled)
+              for (let option of cmd.options)
+                inputs[option].checked = inputs[option].value == cmd.value;
+            else
+              update.disabled = inputs[cmd.value].checked;
+          };
+        } else if (command.type == 'VARIABLE') {
+          row.append(make_name(command.name));
+
+          let slider = make('input', 'control');
+          slider.type = 'range';
+          let number = make('input', 'control');
+          number.type = 'number';
+          for (let input of [ slider, number ]) {
+            input.min   = command.min;
+            input.max   = command.max;
+            input.step  = command.step;
+            input.value = command.value;
+            row.append(input);
+          };
+
+          let update = make('button', 'control-update');
+
+          function oninput(one, another) {
+            another.value   = one.value;
+            update.disabled = one.value == command.value;
+          };
+
+          slider.addEventListener('input', () => void oninput(slider, number));
+          number.addEventListener('input', () => void oninput(number, slider));
+
+          update.textContent = 'Update';
+          update.disabled = true;
+          update.addEventListener(
+            'click',
+            function () {
+              send_command(command.name, number.value);
+              command.value   = number.value;
+              update.disabled = true;
+            }
+          );
+
+          row.append(update);
+
+          controls[command.name] = function (cmd) {
+            command.value = cmd.value;
+            if (update.disabled)
+              number.value = slider.value = cmd.value;
+            else
+              update.disabled = number.value == cmd.value;
+          };
+        };
+        div.append(row);
+      };
+      div.append(output);
+
+      // TODO: how to stop the timeout if the div is destroyed?
+      let delay = 5000;
+      let timeout;
+      function update() {
+        getControls(service).then(
+          function (commands) {
+            for (let command of commands) {
+              let control = controls[command.name];
+              if (control) control(command);
+            };
+            timeout = setTimeout(update, delay);
+          }
+        )
+      };
+      timeout = setTimeout(update, delay);
+
+      // We could use a global Symbol for controls_stop to avoid clashes.
+      div.dataset.controls_stop = () => void cancelTimeout(timeout);
+      return div;
+    }
+  );
+};
+
+// This is to allow developers to play with the functions in the browser console.
+window.modules ??= {};
+window.modules.tooldaq = {
+  db,
+  dbJson,
+  dbPlot,
+  dbTable,
+  request,
+  requestCSV,
+  requestHTML,
+  requestJson,
+  requestText,
+  getControls,
+  getMonitoringPlot,
+  getPlotlyPlot,
+  getService,
+  getServices,
+  makeControls,
+  makeMonitoringPlot,
+  makePlotlyPlot,
+  makeTable,
+  parseCSV,
+  sendCommand,
+};

--- a/html-Common/includes/tooldaq.js
+++ b/html-Common/includes/tooldaq.js
@@ -151,12 +151,15 @@ export function request(url, args, options) {
     options = { method: 'POST', body: options };
 
   return fetch(url, options).then(
-    function (response) {
-      if (!response.ok)
+    async function (response) {
+      if (!response.ok) {
+        let message = await response.text();
+        if (message != null && message != '') message = ': ' + message;
         throw new RequestError(
-          `Request ${response.url} failed with status ${response.status} ${response.statusText}`,
+          `Request ${response.url} failed with status ${response.status} ${response.statusText}${message}`,
           response
         );
+      };
       return response;
     }
   );

--- a/html-Detector/includes/tooldaq.js
+++ b/html-Detector/includes/tooldaq.js
@@ -1,0 +1,1 @@
+../../html-Common/includes/tooldaq.js

--- a/html-Detector/services.txt
+++ b/html-Detector/services.txt
@@ -1,0 +1,1 @@
+/tmp/table_file

--- a/html-StandAlone/includes/tooldaq.js
+++ b/html-StandAlone/includes/tooldaq.js
@@ -1,0 +1,1 @@
+../../html-Common/includes/tooldaq.js

--- a/html-StandAlone/services.txt
+++ b/html-StandAlone/services.txt
@@ -1,0 +1,1 @@
+/tmp/table_file

--- a/html-StandAlone/tooldaq.js
+++ b/html-StandAlone/tooldaq.js
@@ -1,0 +1,1 @@
+../html-Common/includes/tooldaq.js

--- a/src/backgroundSD2.cpp
+++ b/src/backgroundSD2.cpp
@@ -55,8 +55,6 @@ int main (){
     if (myfile.is_open())
       {
 	
-	myfile<<"Content-type:text/html"<<std::endl<<std::endl<<"<html><body>"<<std::endl;
-	
 	Ireceive.send(send);
 	
 	
@@ -80,7 +78,6 @@ int main (){
 	  
 	}
 	
-	myfile<<std::endl<<"<body/><html/>"<<std::endl;
 	myfile.close();
 	
 	sleep(2);


### PR DESCRIPTION
Introduce `tooldaq.js` which is intended to replace `functions.js` eventually. It should be able to do everything that `functions.js` does now, but with error handling and hopefully more concise interface. See `docs/tooldaq.mkd` for the documentation.

I may have overengineered the `makeTable` function. Let me know what you think about it.

New files and changes to old ones:
- `cgi-bin/command.cgi` is used to send commands. It does the same thing as `sendcommand.cgi`, but emits no HTML code, just the command reply as plain text, and also returns code 500 with an error message if something goes wrong.
- `cgi-bin/db-query.cgi` is used to talk to the database. It can return data in JSON or in CSV format, both of which can be handled in `tooldaq.js`. CSV format should use less bandwidth, but sometimes JSON is more convenient. Hopefully it will replace `sqlquery.cgi`, `sqlqueryjson.cgi` and `sqlquerystring.cgi`.
- There is now `services.txt` in `html-Detector` and `html-Standalone*` which is a symlink to `/tmp/table_file`. That way `httpd` doesn't need to execute a CGI script to distribute the table. This should make `tablecontent5.cgi` obsolete.
- `cgi-bin/backgroundSD2` was changed to not emit Content-type header and HTML code. They are ignored anyway in `functions.js`'s `GetSDTable`, so it doesn't break old code. Now the table file (`services.txt`) can be served as plain text.