### PR TITLE
Enhance audio autoplay permission check

### DIFF
--- a/html-Common/includes/alarm_footer.js
+++ b/html-Common/includes/alarm_footer.js
@@ -17,15 +17,30 @@ function sleep (ms) {
 
 // Check if autoplay for audio is allowed
 function checkAutoplayPermission() {
+    const audioPermission = localStorage.getItem('audioPermission');
+    if (audioPermission === 'granted') {
+        // console.log('Autoplay permission already granted');
+        return;
+    }
+
+    audio.muted = true;
     audio.play().then(() => {
-        console.log('Autoplay is allowed');
+        // console.log('Autoplay is allowed');
+        audio.pause();
+        audio.currentTime = 0;
+        audio.muted = false;
+        localStorage.setItem('audioPermission', 'granted');
     }).catch(() => {
-        showEnableAudioButton();
+        // showEnableAudioButton();
+        if (!document.getElementById('enableAudioButton')) {
+            showEnableAudioButton();
+        }
     });
 }
 
 function showEnableAudioButton() {
     var enableAudioBtn = document.createElement('button');
+    enableAudioBtn.id = 'enableAudioButton';
     enableAudioBtn.innerText = 'Enable Sound';
     enableAudioBtn.style.position = 'fixed';
     enableAudioBtn.style.bottom = '20px';
@@ -37,6 +52,7 @@ function showEnableAudioButton() {
         audio.play().then(() => {
             alert('Audio enabled! Alarm sound will play next time.');
             enableAudioBtn.remove();
+            localStorage.setItem('audioPermission', 'granted');
         }).catch((error) => {
             console.error('Audio playback failed:', error);
         });

--- a/html-Common/includes/footer.html
+++ b/html-Common/includes/footer.html
@@ -2,9 +2,8 @@
   <div class="mdl-mega-footer--top-section">
     <div class="mdl-mega-footer--left-section">
       <button id="test_alarm"> test alarm</button>
-      <button id="enableAudioBtn" style="display:none;">Click to enable sound</button>
       <div id="permissionMessage"></div>
-      <input type="text" id="alarm_message" value="no current alarm" class="field left" readonly> 
+      <input type="text" id="alarm_message" value="no current alarm" class="field left" readonly>
       <button onclick="location.href = '/Alarms/index.html'"> Alarms page </button>
     </div>
     <div class="mdl-mega-footer--right-section">
@@ -18,7 +17,7 @@
     <p class="mdl-typography--font-light">ToolDAQ © 2016 </p>
     <p class="mdl-typography--font-light">Created by Dr. B.Richards (benjamin.richards@warwick.ac.uk)</p>
   </div>
-</footer>   
+</footer>
 
 
 


### PR DESCRIPTION
Currently, the audio autoplay functionality test plays a sound that is not an ideal UX.
This fix mutes the audio during such test and creates a local storage item to track
this permission on subsequent visits by the same user on the same browser.