### PR TITLE
minor improvements to SetupDatabase.sh and Dockerfile

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -49,7 +49,8 @@ RUN cd /opt \
 RUN sed -e 's/#LoadModule mpm_prefork_module/LoadModule mpm_prefork_module/' -i /etc/httpd/conf.modules.d/00-mpm.conf \
     && sed -e '/LoadModule mpm_event_module/ s/^#*/#/' -i /etc/httpd/conf.modules.d/00-mpm.conf
 
-RUN echo "unalias cp" >>  /etc/rc.local ;\
+RUN echo "CP=$(type -t cp)" >> /etc/rc.local ;\
+    echo "if [ ! -z "${CP}" ]; then unalias cp; fi" >>  /etc/rc.local ;\
     echo "cp -f /web/httpd.conf /etc/httpd/conf/" >>  /etc/rc.local ;\
     echo "alias cp='cp -i'" >>  /etc/rc.local ;\
     echo "chmod a+x /web/SetupDatabase.sh" >>  /etc/rc.local ;\
@@ -59,7 +60,6 @@ RUN echo "unalias cp" >>  /etc/rc.local ;\
     echo "cd /web && make clean && make" >>  /etc/rc.local ;\
     echo "cd /web/cgi-bin && make clean && make" >>  /etc/rc.local ;\
     echo "/web/SetupDatabase.sh" >> /etc/rc.local ;\
-    echo "sudo -u postgres /usr/bin/pg_ctl start -D /var/lib/pgsql/data -s -o \"-p 5432\" -w -t 300;" >> /etc/rc.local;\
     echo "/opt/middleman/run_middleman.sh &> /dev/null &" >> /etc/rc.local ;\
     echo 'disown $!' >> /etc/rc.local ;\
     echo "/web/Win_Mac_translation_server  &> /dev/null &" >> /etc/rc.local ;\

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -28,7 +28,7 @@ RUN cd /opt \
     && git clone https://github.com/ToolDAQ/middleman.git \
     && cd middleman/ \
     && git checkout v3.0 \
-    && ./Setup.sh \
+    && . Setup.sh \
     && make
 
 # docs build fails if index.html is not present, which kills the docker build

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -56,7 +56,7 @@ RUN echo "CP=$(type -t cp)" >> /etc/rc.local ;\
     echo "chmod a+x /web/SetupDatabase.sh" >>  /etc/rc.local ;\
     echo "chmod a+x /opt/middleman/run_middleman.sh" >>  /etc/rc.local ;\
     echo "chmod a+x /opt/middleman/Setup.sh" >>  /etc/rc.local ;\
-    echo "export LD_LIBRARY_PATH=/lib/:/opt/ToolFrameworkCore/lib:/opt/ToolDAQFramework/lib:/opt/boost_1_66_0/install/lib:/opt/zeromq-4.0.7/lib:/opt/libpqxx-6.4.5/install/lib:$LD_LIBRARY_PATH" >> /etc/rc.local ;\
+    echo 'export LD_LIBRARY_PATH=/lib/:/opt/ToolFrameworkCore/lib:/opt/ToolDAQFramework/lib:/opt/boost_1_66_0/install/lib:/opt/zeromq-4.0.7/lib:/opt/libpqxx-6.4.5/install/lib:$LD_LIBRARY_PATH' >> /etc/rc.local ;\
     echo "cd /web && make clean && make" >>  /etc/rc.local ;\
     echo "cd /web/cgi-bin && make clean && make" >>  /etc/rc.local ;\
     echo "/web/SetupDatabase.sh" >> /etc/rc.local ;\

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -49,8 +49,8 @@ RUN cd /opt \
 RUN sed -e 's/#LoadModule mpm_prefork_module/LoadModule mpm_prefork_module/' -i /etc/httpd/conf.modules.d/00-mpm.conf \
     && sed -e '/LoadModule mpm_event_module/ s/^#*/#/' -i /etc/httpd/conf.modules.d/00-mpm.conf
 
-RUN echo "CP=$(type -t cp)" >> /etc/rc.local ;\
-    echo "if [ ! -z "${CP}" ]; then unalias cp; fi" >>  /etc/rc.local ;\
+RUN echo 'CP=$(type -t cp)' >> /etc/rc.local ;\
+    echo 'if [ ! -z "${CP}" ]; then unalias cp; fi' >>  /etc/rc.local ;\
     echo "cp -f /web/httpd.conf /etc/httpd/conf/" >>  /etc/rc.local ;\
     echo "alias cp='cp -i'" >>  /etc/rc.local ;\
     echo "chmod a+x /web/SetupDatabase.sh" >>  /etc/rc.local ;\

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ to create docker container with webserver in use:
 
 linux:
 
-      docker run --name=WebServer -v local_git_clone_path:/web --mount type=tmpfs,dst=/tmp,tmpfs-size=500M --net=host -dt tooldaq/server
+      docker run --name=WebServer -v local_git_clone_path:/web --mount type=tmpfs,dst=/tmp,tmpfs-size=500M --net=host --cap-add=CAP_AUDIT_WRITE -dt tooldaq/server
 
 Windows / MacOS:
 


### PR DESCRIPTION
Suppress cp alias warning. Add docker flag to suppress audit permissions warnings. Use systemd when available for postgres service, falling back to pg_ctl when unavailable (i.e. in containers). Remove redundant call to start database in rc.local to suppress warning. Add listen on all addresses to posgtresql.conf, and enable database checksums.