### PR TITLE
Changing the header to dynamically show the current page and sub-page

### DIFF
--- a/html-Detector/includes/header.html
+++ b/html-Detector/includes/header.html
@@ -16,6 +16,23 @@
 <script defer src="/stylesheets/material.min.js" async></script>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+<!-- Dynamically change header title to display current directory and sub-directory -->
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+    let path_name = window.location.pathname.replace(/\.html$/, "");
+    if (path_name !== "/index" && path_name !== "/") {
+        let path_array = path_name.split("/").filter(part => part);
+        let dir = path_array[0].charAt(0).toUpperCase() + path_array[0].slice(1);
+        let subdir = path_array[1] ? path_array[1].charAt(0).toUpperCase() + path_array[1].slice(1) : "";
+        title = subdir ? `${dir} › ${subdir}` : dir;
+    }
+    const header_title = document.querySelector(".mdl-layout-title");
+    if (header_title) {
+        header_title.textContent = title;
+    }
+});
+</script>
+
 <!-- <link rel="stylesheet" href="/styles.css">   -->
 
 </head>

--- a/html-StandAlone/includes/header.html
+++ b/html-StandAlone/includes/header.html
@@ -17,6 +17,23 @@
 <script defer src="/stylesheets/material.min.js" async></script>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+<!-- Dynamically change header title to display current directory and sub-directory -->
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+    let path_name = window.location.pathname.replace(/\.html$/, "");
+    if (path_name !== "/index" && path_name !== "/") {
+        let path_array = path_name.split("/").filter(part => part);
+        let dir = path_array[0].charAt(0).toUpperCase() + path_array[0].slice(1);
+        let subdir = path_array[1] ? path_array[1].charAt(0).toUpperCase() + path_array[1].slice(1) : "";
+        title = subdir ? `${dir} › ${subdir}` : dir;
+    }
+    const header_title = document.querySelector(".mdl-layout-title");
+    if (header_title) {
+        header_title.textContent = title;
+    }
+});
+</script>
+
 <!-- <link rel="stylesheet" href="/styles.css">   -->
 
 


### PR DESCRIPTION
New identical scripts were made and added to `header.html` in `html-StandAlone` and `html-Detector`.

These display the current page and sub-page as 'Page > Sub-page' in place of 'ToolDAQ Webpage' in the header; the landing page defaults to 'ToolDAQ Webpage' for now. 

Tested on several browsers.

Please let me know if this can be refined in any way, such as whether the script could be stored in a separate .js file, or any other changes/fixes.