### PR TITLE
Dockerfile.server: provide a relative path to . when building middleman

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -28,7 +28,7 @@ RUN cd /opt \
     && git clone https://github.com/ToolDAQ/middleman.git \
     && cd middleman/ \
     && git checkout v3.0 \
-    && . Setup.sh \
+    && . ./Setup.sh \
     && make
 
 # docs build fails if index.html is not present, which kills the docker build


### PR DESCRIPTION
Fix
```
 => ERROR [4/7] RUN cd /opt     && git clone https://github.com/ToolDAQ/middleman.git     && cd middleman/     && git checkout v3.0     && . Setup.sh     && make                         0.8s
------
 > [4/7] RUN cd /opt     && git clone https://github.com/ToolDAQ/middleman.git     && cd middleman/     && git checkout v3.0     && . Setup.sh     && make:
0.173 Cloning into 'middleman'...
0.761 Switched to a new branch 'v3.0'
0.761 branch 'v3.0' set up to track 'origin/v3.0'.
0.762 /bin/sh: line 1: .: Setup.sh: file not found
------
Dockerfile:27
--------------------
  26 |
  27 | >>> RUN cd /opt \
  28 | >>>     && git clone https://github.com/ToolDAQ/middleman.git \
  29 | >>>     && cd middleman/ \
  30 | >>>     && git checkout v3.0 \
  31 | >>>     && . Setup.sh \
  32 | >>>     && make
  33 |
--------------------
ERROR: failed to solve: process "/bin/sh -c cd /opt     && git clone https://github.com/ToolDAQ/middleman.git     && cd middleman/     && git checkout v3.0     && . Setup.sh     && make" did not complete successfully: exit code: 1
```
when compiling `middleman` while building the container