### PR TITLE
adding <!DOCTYPE html> to existing pages in html-Detector configuration

### DIFF
--- a/html-Common/Control/device.html
+++ b/html-Common/Control/device.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 
 <head>
   <title>ToolDAQ Webpage</title>

--- a/html-Common/Control/index.html
+++ b/html-Common/Control/index.html
@@ -1,3 +1,5 @@
+<!DOCTYPE html>
+
 <html>
   <head>
     <title>ToolDAQ Webpage</title>

--- a/html-Common/Logs/index.html
+++ b/html-Common/Logs/index.html
@@ -1,3 +1,5 @@
+<!DOCTYPE html>
+
 <head>
 <title>ToolDAQ Webpage</title>
 

--- a/html-Common/Logs/logs.html
+++ b/html-Common/Logs/logs.html
@@ -1,3 +1,5 @@
+<!DOCTYPE html>
+
 <head>
   <title>ToolDAQ Webpage</title>
   

--- a/html-Common/Monitoring/index.html
+++ b/html-Common/Monitoring/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 
 <html>
 	<head>

--- a/html-Common/Monitoring/monitoringfiles.html
+++ b/html-Common/Monitoring/monitoringfiles.html
@@ -1,3 +1,5 @@
+<!DOCTYPE html>
+
 <head>
   <title>ToolDAQ Webpage</title>
   

--- a/html-Common/SQL/index.html
+++ b/html-Common/SQL/index.html
@@ -1,3 +1,5 @@
+<!DOCTYPE html>
+
 <html>
   <head>
     <title>ToolDAQ Webpage</title>

--- a/html-Detector/Config/index.html
+++ b/html-Detector/Config/index.html
@@ -1,3 +1,5 @@
+<!DOCTYPE html>
+
 <html>
 
 <head>

--- a/html-Detector/DAQ/RunControl/index.html
+++ b/html-Detector/DAQ/RunControl/index.html
@@ -1,3 +1,5 @@
+<!DOCTYPE html>
+
 <head>
 <title>ToolDAQ Webpage</title>
 

--- a/html-Detector/Shift/index.html
+++ b/html-Detector/Shift/index.html
@@ -1,3 +1,5 @@
+<!DOCTYPE html>
+
 <head>
 <title>ToolDAQ Webpage</title>
 </head>

--- a/html-Detector/Shift/pageA/index.html
+++ b/html-Detector/Shift/pageA/index.html
@@ -1,3 +1,5 @@
+<!DOCTYPE html>
+
 <head>
 <title>ToolDAQ Webpage</title>
 

--- a/html-Detector/SubSystemExample/index.html
+++ b/html-Detector/SubSystemExample/index.html
@@ -1,3 +1,5 @@
+<!DOCTYPE html>
+
 <head>
 <title>ToolDAQ Webpage</title>
 </head>

--- a/html-Detector/SubSystemExample/pageA/index.html
+++ b/html-Detector/SubSystemExample/pageA/index.html
@@ -1,3 +1,5 @@
+<!DOCTYPE html>
+
 <head>
 <title>ToolDAQ Webpage</title>
 </head>

--- a/html-Detector/SubSystemExample/protected/pageB/index.html
+++ b/html-Detector/SubSystemExample/protected/pageB/index.html
@@ -1,3 +1,5 @@
+<!DOCTYPE html>
+
 <head>
 <title>ToolDAQ Webpage</title>
 

--- a/html-Detector/SubSystemTemplate/index.html
+++ b/html-Detector/SubSystemTemplate/index.html
@@ -1,3 +1,5 @@
+<!DOCTYPE html>
+
 <head>
 <title>ToolDAQ Webpage</title>
 </head>

--- a/html-Detector/SubSystemTemplate/pageA/index.html
+++ b/html-Detector/SubSystemTemplate/pageA/index.html
@@ -1,3 +1,5 @@
+<!DOCTYPE html>
+
 <head>
 <title>ToolDAQ Webpage</title>
 

--- a/html-Detector/SubSystemTemplate/protected/pageB/index.html
+++ b/html-Detector/SubSystemTemplate/protected/pageB/index.html
@@ -1,3 +1,5 @@
+<!DOCTYPE html>
+
 <head>
 <title>ToolDAQ Webpage</title>
 


### PR DESCRIPTION
Several minor formatting bugs occurred because of the lack of document tag.

This meant that:
(i) The font sizes for 'exp time/user time/login' above the header were inconsistent between tabs
(ii) The materials icon for the drawer was misaligned with header text on pages without the tag

Issue (i) is shown at:
https://github.com/ToolDAQ/WebServer/issues/58

Issue (ii) is shown in a screenshot below.

<img width="431" alt="Screenshot 2025-02-20 at 16 47 06" src="https://github.com/user-attachments/assets/2ff7f40b-7271-4cf8-9088-a742d41644e0" />

Adding <!DOCTYPE html> before the html tags fixes both issues:

<img width="451" alt="Screenshot 2025-02-20 at 16 45 55" src="https://github.com/user-attachments/assets/d491ca85-71e2-459c-ab12-2b68ef7922ac" />

Checked on multiple browsers, but this is a very minor formatting change.

