### PR TITLE
Update clocks to UTC and experiment local time...

### DIFF
--- a/html-Common/includes/statusbar.js
+++ b/html-Common/includes/statusbar.js
@@ -1,5 +1,5 @@
-let usertime=document.getElementById("usertime");
-let exptime=document.getElementById("exptime");
+let usertime=document.getElementById("utctime");
+let exptime=document.getElementById("localtime");
 let user=document.getElementById("user");
 
 function getTimeInTimezones() {
@@ -10,7 +10,7 @@ function getTimeInTimezones() {
 
     // Get the time in the defined timezone
     exptime.innerText = new Date().toLocaleTimeString(undefined, {
-        timeZone: "Europe/London"
+        timeZone: 'UTC'
     });
 
 }

--- a/html-Common/includes/statusbar.js
+++ b/html-Common/includes/statusbar.js
@@ -1,16 +1,17 @@
-let usertime=document.getElementById("utctime");
-let exptime=document.getElementById("localtime");
+let utctime=document.getElementById("utctime");
+let exptime=document.getElementById("exptime");
 let user=document.getElementById("user");
 
 function getTimeInTimezones() {
     // Get the current time in the user's timezone
-    usertime.innerText = new Date().toLocaleTimeString(undefined, {
-        timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone
+    utctime.innerText = new Date().toLocaleTimeString(undefined, {
+        timeZone: 'UTC'
     });
 
     // Get the time in the defined timezone
     exptime.innerText = new Date().toLocaleTimeString(undefined, {
-        timeZone: 'UTC'
+        // FIXME this should be set to local timezone of the experiment
+        timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone
     });
 
 }

--- a/html-Detector/includes/header.html
+++ b/html-Detector/includes/header.html
@@ -43,8 +43,8 @@
     <tr>
       <td style="border: none; padding: 10px; width: 15%; text-align: right;">Exp time:</td>
       <td style="border: none; padding: 10px; width: 15%; text-align: left;" id="exptime" ></td>
-      <td style="border: none; padding: 10px; width: 15%; text-align: right;">User time:</td>
-      <td style="border: none; padding: 10px; width: 15%; text-align: left;" id="usertime"></td>
+      <td style="border: none; padding: 10px; width: 15%; text-align: right;">UTC time:</td>
+      <td style="border: none; padding: 10px; width: 15%; text-align: left;" id="utctime"></td>
       <td style="border: none; padding: 10px; width: 15%; text-align: right;">UserName:</td>
       <td style="border: none; padding: 10px; width: 15%; text-align: left;" id="user"></td>
       <td style="border: none; padding: 10px; width: 10%; text-align: right;"> <a href="/login.html">Log Out</a></td>

--- a/html-Detector/includes/headerA.html
+++ b/html-Detector/includes/headerA.html
@@ -43,8 +43,8 @@
     <tr>
       <td style="border: none; padding: 10px; width: 15%; text-align: right;">Exp time:</td>
       <td style="border: none; padding: 10px; width: 15%; text-align: left;" id="exptime" ></td>
-      <td style="border: none; padding: 10px; width: 15%; text-align: right;">User time:</td>
-      <td style="border: none; padding: 10px; width: 15%; text-align: left;" id="usertime"></td>
+      <td style="border: none; padding: 10px; width: 15%; text-align: right;">UTC time:</td>
+      <td style="border: none; padding: 10px; width: 15%; text-align: left;" id="utctime"></td>
       <td style="border: none; padding: 10px; width: 15%; text-align: right;">UserName:</td>
       <td style="border: none; padding: 10px; width: 15%; text-align: left;" id="user"></td>
       <td style="border: none; padding: 10px; width: 10%; text-align: right;"> <a href="/login.html">Log Out</a></td>


### PR DESCRIPTION
currently one clock is fixed to English time, which is no use to anyone.
The other is fixed to the user's local time, which is not particularly relevant either.

The two clocks that *are* relevant are UTC (which will be used for all experimental timestamps) and experiment local time (which will be relevant for communication with on-site personnel). 
English time clock is now changed to UTC.
"Experiment" time clock is still set to user's local time, but we should make a note to change this to actual experiment's local timezone on deployment.