### PR TITLE
Minor README changes to include sym link info and fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # WebServer
 
-to create docker container with webserver in use:
+To create a Docker container with WebServer in use:
 
-linux:
+Linux:
 
       docker run --name=WebServer -v local_git_clone_path:/web --mount type=tmpfs,dst=/tmp,tmpfs-size=500M --net=host --cap-add=CAP_AUDIT_WRITE -dt tooldaq/server
 
 Windows / MacOS:
 
-(if client is on a differnt computer)
+(if client is on a different computer)
 
       docker run --name=WebServer -v local_git_clone_path:/web --mount type=tmpfs,dst=/tmp,tmpfs-size=500M -p 80:80 -p 5000:5000:udp -dt tooldaq/server
 
@@ -16,7 +16,7 @@ Windows / MacOS:
 
       docker run --name=WebServer -v local_git_clone_path:/web --mount type=tmpfs,dst=/tmp,tmpfs-size=500M -p 80:80 -p 666:666 -p 667:667 -dt tooldaq/server   
 
-*note: If your using Windows or MacOs and want to comunicate to the web server on the same computer as any aplications running on the hostOS you will also need to run the Win_Mac_translation program in the background on the hostOS, this can be found in the standalone branch
+*note: If you're using Windows or MacOs and want to comunicate to the web server on the same computer as any aplications running on the hostOS you will also need to run the Win_Mac_translation program in the background on the hostOS, this can be found in the standalone branch:
 
       ./Win_Mac_translation &
 
@@ -26,8 +26,14 @@ To subsequently start and stop web server use:
       docker stop WebServer
 
 
-Note: Be aware that rapid stop and start may not allow the container to run as the system may have not released the port binding. To check if the web server really is running use:
+Note: be aware that rapid stop and start may not allow the container to run as the system may have not released the port binding. To check if WebServer really is running use:
 
       docker ps 
 
-If Webserver is not listed wait a few mins and try to start again.
+If WebServer is not listed wait a few minutes and try to start again.
+
+By default, the html folder is symbolically linked to html-StandAlone, to instead link to html-Detector, do:
+
+      unlink html
+      ln -s html-Detector html
+


### PR DESCRIPTION
As title says, fix typos and add information about the symbolic link so users know how to switch to html-Detector without issue.