### PR TITLE
Tab redirection to first sub-page

### DIFF
--- a/html-Detector/DAQ/index.html
+++ b/html-Detector/DAQ/index.html
@@ -1,3 +1,5 @@
+<!DOCTYPE html>
+
 <head>
 <meta http-equiv="refresh" content="0; url=./RunControl" />
 <title>ToolDAQ Webpage</title>

--- a/html-Detector/Shift/index.html
+++ b/html-Detector/Shift/index.html
@@ -12,5 +12,6 @@
 
 
 
-AAAA
+Subsystem main page
+
 <!--#include virtual="/includes/footer.html" -->

--- a/html-Detector/Shift/index.html
+++ b/html-Detector/Shift/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 
 <head>
+<meta http-equiv="refresh" content="0; url=./pageA" />
 <title>ToolDAQ Webpage</title>
 </head>
 
@@ -11,6 +12,5 @@
 
 
 
-Subsystem main page
-
+AAAA
 <!--#include virtual="/includes/footer.html" -->

--- a/html-Detector/SubSystemExample/index.html
+++ b/html-Detector/SubSystemExample/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 
 <head>
+  <meta http-equiv="refresh" content="0; url=./intro" />
 <title>ToolDAQ Webpage</title>
 </head>
 


### PR DESCRIPTION
Automatically re-direct to first subpage when clicking on a tab. 

The DAQ/Shift/SubSystemExample tabs have multiple sub-pages and clicking on these tabs currently directs you to an arbitrary unfilled /index.html page. This now directs you to DAQ/RunControl, Shift/pageA and SubSystemExample/intro. 

Tabs with just a single subpage are unaffected for now until more subpages are added.