### PR TITLE
tooldaq.js: getMonitoringPlot: fix timezone offset application

### DIFF
--- a/html-Common/includes/tooldaq.js
+++ b/html-Common/includes/tooldaq.js
@@ -254,7 +254,7 @@ export function getMonitoringPlot(device, options) {
 
   function encodeDate(date) {
     if (date instanceof Date)
-      return date.toISOString() + date.getTimezoneOffset();
+      return date.toISOString() + date.getTimezoneOffset() / 60;
     return date;
   };
 


### PR DESCRIPTION
Date.getTimezoneOffset() returns minutes, not hours