### PR TITLE
Remove unused postgres extensions

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -2,20 +2,19 @@
 FROM tooldaq/web_base
 
 RUN yum install -y                   \
-                httpd                \
-                postgresql-server    \
-                postgresql-devel     \
-                postgresql-contrib   \
-                libpq                \
-                sudo                 \
-                procps-ng            \
-                psmisc               \
-                emacs                \
-                libpcap-devel        \
-                iputils              \
-                iproute              \
- && yum clean all                    \
- && rm -rf /var/cache/yum
+    httpd                \
+    postgresql-server    \
+    postgresql-devel     \
+    libpq                \
+    sudo                 \
+    procps-ng            \
+    psmisc               \
+    emacs                \
+    libpcap-devel        \
+    iputils              \
+    iproute              \
+    && yum clean all                    \
+    && rm -rf /var/cache/yum
 
 RUN cd /opt \
     && wget https://github.com/ToolDAQ/libpqxx/raw/master/libpqxx-6.4.5_fixed.tar.gz \

--- a/SetupDatabase.sh
+++ b/SetupDatabase.sh
@@ -56,9 +56,6 @@ sudo -u postgres createuser -s root
 echo "creating 'daq' database"
 sudo -u postgres psql -c "create database daq with owner=root;"
 
-echo "creating pgcrypto extension"
-psql -ddaq -c "CREATE EXTENSION IF NOT EXISTS pgcrypto;"
-
 # set timezone to UTC
 psql -ddaq -c "ALTER DATABASE daq SET TIME ZONE 'UTC';"
 


### PR DESCRIPTION
We decided to use client-side password encryption instead of the native pgcrypto extension. 
This change drops the unused extensions in Dockerfile and SetupDatabase script.