### PR TITLE
SubsystemReGenerate script creates link to first tab in subsystem's tablist

### DIFF
--- a/html-Common/SubsystemReGenerate.sh
+++ b/html-Common/SubsystemReGenerate.sh
@@ -2,6 +2,24 @@
 
 subsystem=$(basename `pwd`)
 
+# Do nothing if the subsystem page has no tablist
+tablist_file="tablist"
+[[ -f "$tablist_file" ]] || exit 0
+
+
+# Make $subsystem/index.html always redirect to the first tab in the tablist
+index_file="index.html"
+first_tab=$(head -n 1 "$tablist_file")
+if [[ -f "$index_file" ]]; then
+  if grep -q '<meta http-equiv="refresh"' "$index_file"; then
+    sed -i "s|<meta http-equiv=\"refresh\"[^>]*>|<meta http-equiv=\"refresh\" content=\"0; url=./$first_tab\" />|" "$index_file"
+  else
+    sed -i "/<head>/a <meta http-equiv=\"refresh\" content=\"0; url=./$first_tab\" />" "$index_file"
+  fi
+fi
+
+
+# Build sub-header
 cat ../includes/headerC.html >subheader.html
 
 for folder in `more tablist`


### PR DESCRIPTION
Running `SubsystemReGenerate.sh` now creates a meta refresh immediately after `<head>` which links to the first tab in a subsystem's tablist if it exists.

For example, running this in /DAQ will produce the following line in /DAQ/index.html:

`<meta http-equiv="refresh" content="0; url=./RunControl" />
`

as RunControl is the first line in /DAQ/tablist

If a line of this format already exists, it will replace the url if it does not correspond to the first in the tablist.

Also added a failsafe line which stops the code from running if a tablist does not exist; running this by accident in subsystem folders with no tablist (e.g. /Alarms) previously created problems.