### PR TITLE
Logs page fix:

### DIFF
--- a/html-Common/Logs/index.html
+++ b/html-Common/Logs/index.html
@@ -1,49 +1,52 @@
 <!DOCTYPE html>
 
 <head>
-<title>ToolDAQ Webpage</title>
-
+  <title>ToolDAQ Webpage</title>
 </head>
 
 <!--#include virtual="/includes/header.html" -->
 <!--#include virtual="../subheader.html" -->
 
-<div id="logtabbar" class="mdl-layout__tab-bar mdl-js-ripple-effect is-casting-shadow mdl-js-ripple-effect--ignore-events" data-upgraded=",MaterialRipple">  <!--class="mdl-layout__tab-bar mdl-js-ripple-effect" >-->
+<div id="logtabbar"
+  class="mdl-layout__tab-bar mdl-js-ripple-effect is-casting-shadow mdl-js-ripple-effect--ignore-events"
+  data-upgraded=",MaterialRipple"> <!--class="mdl-layout__tab-bar mdl-js-ripple-effect" >-->
 </div>
 
 <!--#include virtual="/includes/drawer.html" -->
 
-<div class="mdl-layout mdl-js-layout">
-  <div class="mdl-layout__content">
-      <div class="page-content">
-          <h2>Log Viewer</h2>
-          <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-            <input type="text" id="log-device-input" class="mdl-textfield__input" placeholder="Type to search device..." autocomplete="off">
-            <div id="device-suggestions" class="autocomplete-list"></div>
-          </div>
-
-          <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
-              <input class="mdl-textfield__input" type="number" id="log-line-count" min="1" required>
-              <label class="mdl-textfield__label" for="log-line-count">Number of lines</label>
-          </div>
-
-          <label>
-            <input type="checkbox" id="auto-refresh-checkbox">
-            Enable Auto Refresh
-          </label>
-
-          <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label" id="auto-refresh-container" style="display: none;">
-            <input class="mdl-textfield__input" type="number" id="log-update-interval" min="15">
-            <label class="mdl-textfield__label" for="log-update-interval">Log refresh frequency in seconds</label>
-            <p id="refresh-feedback" style="color: #00796b; font-size: 14px; margin-top: 5px;"></p>
-          </div>
-
-          <button class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored" id="fetch-logs-button">
-              Show Logs
-          </button>
-
-          <div id="logs-container"></div>
+<div class>
+  <div class=" mdl-layout__content">
+    <div class="page-content">
+      <h2>Log Viewer</h2>
+      <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+        <input type="text" id="log-device-input" class="mdl-textfield__input" placeholder="Type to search device..."
+          autocomplete="off">
+        <div id="device-suggestions" class="autocomplete-list"></div>
       </div>
+
+      <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+        <input class="mdl-textfield__input" type="number" id="log-line-count" min="1" required>
+        <label class="mdl-textfield__label" for="log-line-count">Number of lines</label>
+      </div>
+
+      <label>
+        <input type="checkbox" id="auto-refresh-checkbox">
+        Enable Auto Refresh
+      </label>
+
+      <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label" id="auto-refresh-container"
+        style="display: none;">
+        <input class="mdl-textfield__input" type="number" id="log-update-interval" min="15">
+        <label class="mdl-textfield__label" for="log-update-interval">Log refresh frequency in seconds</label>
+        <p id="refresh-feedback" style="color: #00796b; font-size: 14px; margin-top: 5px;"></p>
+      </div>
+
+      <button class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored" id="fetch-logs-button">
+        Show Logs
+      </button>
+
+      <div id="logs-container"></div>
+    </div>
   </div>
 </div>
 

--- a/html-Common/Logs/index.html
+++ b/html-Common/Logs/index.html
@@ -14,7 +14,7 @@
 
 <!--#include virtual="/includes/drawer.html" -->
 
-<div class>
+<div style="margin-left: 20px;">
   <div class=" mdl-layout__content">
     <div class="page-content">
       <h2>Log Viewer</h2>

--- a/html-Common/Logs/logs.html
+++ b/html-Common/Logs/logs.html
@@ -2,14 +2,16 @@
 
 <head>
   <title>ToolDAQ Webpage</title>
-  
+
 </head>
 
 <!--#include virtual="/includes/header.html" -->
 <!--#include virtual="../subheader.html" -->
-  
-<div id="logtabbar" class="mdl-layout__tab-bar mdl-js-ripple-effect is-casting-shadow mdl-js-ripple-effect--ignore-events" data-upgraded=",MaterialRipple">  <!--class="mdl-layout__tab-bar mdl-js-ripple-effect" >-->
-</div>  
+
+<div id="logtabbar"
+  class="mdl-layout__tab-bar mdl-js-ripple-effect is-casting-shadow mdl-js-ripple-effect--ignore-events"
+  data-upgraded=",MaterialRipple"> <!--class="mdl-layout__tab-bar mdl-js-ripple-effect" >-->
+</div>
 
 <!--#include virtual="/includes/drawer.html" -->
 


### PR DESCRIPTION
The logs page renders perfectly for the Detector but for the standAlone it's distorted. This distortion appears to be due to some material classes.

This fix addresses the issue by removing those material classes from the markup

Before:
<img width="1272" alt="image" src="https://github.com/user-attachments/assets/2e942651-4098-4a5a-a277-bb20d2a50a3f" />

After:

1. Html-StandAlone
<img width="1259" alt="image" src="https://github.com/user-attachments/assets/ab87410f-e56c-4921-9bb5-fb05ba6a4c2e" />


2. Html-Detector

<img width="1268" alt="image" src="https://github.com/user-attachments/assets/7293782e-afe9-46c7-9f5b-f6829fe20c52" />
