### PR TITLE
Adding spinner to indicate when pages are loading

### DIFF
--- a/html-Common/includes/footer.html
+++ b/html-Common/includes/footer.html
@@ -36,6 +36,8 @@
 <script src="/includes/statusbar.js?v=1" async></script>
 <script type="module" src="/includes/functions.js?v=1" async></script>
 <script type="module" src="/includes/alarm_footer.js?v=1" async></script>
+<script src="/includes/loader.js" defer></script>
+
 
   <script>
   const overlay = document.getElementById('overlay');

--- a/html-Common/includes/loader.js
+++ b/html-Common/includes/loader.js
@@ -1,0 +1,37 @@
+// loader.js displays spinner when pages are loading
+
+(function () {
+  const loader = document.createElement("div");
+  loader.id = "loader";
+  loader.innerHTML = `
+    <div class="spinner"></div>
+    <style>
+      #loader {
+        position: fixed;
+        top: 0; left: 0;
+        width: 100vw; height: 100vh;
+        background: white;
+        z-index: 9999;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .spinner {
+        border: 8px solid #f3f3f3;
+        border-top: 8px solid #3498db;
+        border-radius: 50%;
+        width: 100px; height: 100px;
+        animation: spin 1s linear infinite;
+      }
+      @keyframes spin {
+        0% { transform: rotate(0deg); }
+        100% { transform: rotate(360deg); }
+      }
+    </style>
+  `;
+  document.body.appendChild(loader);
+
+  window.addEventListener("load", () => {
+    loader.remove();
+  });
+})();

--- a/html-Detector/includes/loader.js
+++ b/html-Detector/includes/loader.js
@@ -1,0 +1,1 @@
+../../html-Common/includes/loader.js


### PR DESCRIPTION
Added a rotating spinner to indicate when pages are loading. This is included in footer.html so the loader renders on all pages with the footer.