### PR TITLE
Make example page formats consistent

### DIFF
--- a/html-Detector/SubSystemExample/databaseQueries/index.html
+++ b/html-Detector/SubSystemExample/databaseQueries/index.html
@@ -18,63 +18,66 @@
     <main class="mdl-layout__content">
       <div class="content">
         <div id="database-query">
-          <hr>
           <h2>Database Query Operations</h2>
-          <hr>
           <p>
             The <strong>Database Query Operations</strong> functions are designed to help you interact with ToolDAQ
             databases. These functions include:
           </p>
           <ul>
-            <li><a class="documentation-link" href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#dbJson" target="_blank">dbJson(query)</a> Executes a SQL query and returns the result as JSON.</li>
-            <li><a class="documentation-link" href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#dbtable" target="_blank">dbTable(query, header):</a> Executes a SQL query and returns the result as an array of array.</li>
-            <li><a class="documentation-link" href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#dbPlot" target="_blank">dbPlot(query, template):</a> Executes a SQL query and creates a plot from the results.</li>
+            <li><a class="documentation-link"
+                href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#dbJson"
+                target="_blank">dbJson(query)</a> Executes a SQL query and returns the result as JSON.</li>
+            <li><a class="documentation-link"
+                href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#dbtable"
+                target="_blank">dbTable(query, header):</a> Executes a SQL query and returns the result as an array of
+              array.</li>
+            <li><a class="documentation-link"
+                href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#dbPlot"
+                target="_blank">dbPlot(query, template):</a> Executes a SQL query and creates a plot from the results.
+            </li>
           </ul>
-          <p>Below are detailed explanations and examples for each function:</p>
+          <p>
+            This page shows examples for each function.
+          </p>
+          <hr>
           <div id="db-json-example">
             <h3>dbJson(query)</h3>
             <p>
               <strong>Description:</strong> Executes a SQL query and returns the result as a JSON object.
               This is useful when you need structured data to work with programmatically.
             </p>
-            <p><strong>Example:</strong></p>
-            <pre>
-              <code  class="language-javascript">
-                import { dbJson } from '/includes/tooldaq.js';
-                const query = "SELECT * FROM monitoring LIMIT 10";
-                dbJson(query).then(result => console.log(result));
-              </code>
-            </pre>
+            <p>
+              <strong>Example:</strong>
+            </p>
+            <pre><code  class="language-javascript">import { dbJson } from '/includes/tooldaq.js';
+const query = "SELECT * FROM monitoring LIMIT 10";
+dbJson(query).then(result => console.log(result));</code></pre>
             <p>
               <strong>Output:</strong> The result of the query will be logged to the browser console as JSON.
             </p>
-            <p> You can also use a script tag embedded in your html as follows:</p>
-            <pre>
-              <code class="language-html">
-                &lt;button onclick="runDbJson()"
-                  class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored"&gt;
-                  Run runDbJson
-                &lt;/button&gt;
-                &lt;div id="dbJsonOutput" class="mdl-typography--body-1"&gt;&lt;/div&gt;
+            <p>
+              You can also use a script tag embedded in your html as follows:
+            </p>
+            <pre><code class="language-html">&lt;button onclick="runDbJson()"
+  class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored"&gt;
+  Run runDbJson
+&lt;/button&gt;
+&lt;div id="dbJsonOutput" class="mdl-typography--body-1"&gt;&lt;/div&gt;</code>
 
-                &lt;script&gt;
-                  <code class="language-javascript">
-                    function runDbJson() {
-                      import('/includes/tooldaq.js').then(({ dbJson }) => {
-                        const query = "SELECT * FROM monitoring LIMIT 1";
-                        dbJson(query)
-                          .then(result => {
-                            document.getElementById('dbJsonOutput').innerText = JSON.stringify(result, null, 2);
-                          })
-                          .catch(error => {
-                            document.getElementById('dbJsonOutput').innerText = 'Error: ' + error.message;
-                          });
-                      });
-                    }
-                  </code>
-                &lt;/script&gt;
-              </code>
-            </pre>
+<code class="language-javascript">&lt;script&gt;
+  function runDbJson() {
+    import('/includes/tooldaq.js').then(({ dbJson }) => {
+      const query = "SELECT * FROM monitoring LIMIT 1";
+      dbJson(query)
+        .then(result => {
+          document.getElementById('dbJsonOutput').innerText = JSON.stringify(result, null, 2);
+        })
+        .catch(error => {
+          document.getElementById('dbJsonOutput').innerText = 'Error: ' + error.message;
+        });
+    });
+  }</code>
+&lt;/script&gt;</code></pre>
             <div class="demo-container">
               <button onclick="runDbJsonDemo()" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored">
                 Run dbJson Demo
@@ -101,38 +104,40 @@
           <div id="db-table-example">
             <h3>dbTable(query, header)</h3>
             <p>
-              <strong>Description:</strong>  Executes a SQL query and displays the result as an array of array that can be used to make a HTML table displaying the
-              results.<a class="documentation-link" href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#makeTable" target="_blank"> makeTable()</a> can be used to display it.
+              <strong>Description:</strong> Executes a SQL query and displays the result as an array of array that can
+              be used to make a HTML table displaying the
+              results.<a class="documentation-link"
+                href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#makeTable" target="_blank">
+                makeTable()</a> can be used to display it.
               This is helpful when you want to present query results in a user-friendly tabular format. <br>
-              If <strong>header</strong> is truthy, the first row will contain column names as provided in the query. <br>
-               <strong>query</strong> is a string with an SQL query. Parameters interpolation and string escaping are currently not supported.
+              If <strong>header</strong> is truthy, the first row will contain column names as provided in the query.
+              <br>
+              <strong>query</strong> is a string with an SQL query. Parameters interpolation and string escaping are
+              currently not supported.
             </p>
-            <p><strong>Example:</strong></p>
-            <pre>
-              <code class="language-html">
-                &lt;div id="tableContainer" class="demo-container mdl-shadow--2dp"&gt;&lt;/div&gt;
-                  &lt;button onclick="runDbTable()"
-                    class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored"&gt;
-                    Run dbTable Demo
-                  &lt;/button&gt;
-                  &lt;div id="dbTableOutput" class="mdl-typography--body-1"&gt;&lt;/div&gt;
-                &lt;/div&gt;
-              </code>
-              <code class="language-javascript">
-                import { dbTable } from '/includes/tooldaq.js';
-                const query = "SELECT * FROM monitoring LIMIT 10";
-                const headers = ["Time", "Device", "Data"];
-                function runDbTableDemo() {
-                  dbTable(query, true).then(data => {
-                    const tableContainer = document.getElementById("dbTableOutput");
-                    const table = makeTable(null, data, headers);
-                    tableContainer.appendChild(table);
-                  }).catch(error => {
-                    document.getElementById('dbTableOutput').innerHTML = `<p style="color:red;">Error: ${error.message}</p>`;
-                  });
-                }
-              </code>
-            </pre>
+            <p>
+              <strong>Example:</strong>
+            </p>
+            <pre><code class="language-html">&lt;div id="tableContainer" class="demo-container mdl-shadow--2dp"&gt;&lt;/div&gt;
+  &lt;button onclick="runDbTable()"
+    class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored"&gt;
+    Run dbTable Demo
+  &lt;/button&gt;
+  &lt;div id="dbTableOutput" class="mdl-typography--body-1"&gt;&lt;/div&gt;
+&lt;/div&gt;</code>
+
+<code class="language-javascript">import { dbTable } from '/includes/tooldaq.js';
+const query = "SELECT * FROM monitoring LIMIT 10";
+const headers = ["Time", "Device", "Data"];
+function runDbTableDemo() {
+  dbTable(query, true).then(data => {
+    const tableContainer = document.getElementById("dbTableOutput");
+    const table = makeTable(null, data, headers);
+    tableContainer.appendChild(table);
+  }).catch(error => {
+    document.getElementById('dbTableOutput').innerHTML = `<p style="color:red;">Error: ${error.message}</p>`;
+  });
+}</code></pre>
             <p>
               <strong>Output:</strong> The query results will be displayed in an HTML table within a container element
               with
@@ -215,39 +220,34 @@
             </p>
             <p>
               <strong>Parameters:</strong> <br>
-              <strong>query</strong> is a string with an SQL query. Parameters interpolation and string escaping are currently not supported. <br>
-                <strong>template</strong> can be used to set default values for all returned traces. It should be an object (possibly null)
+              <strong>query</strong> is a string with an SQL query. Parameters interpolation and string escaping are
+              currently not supported. <br>
+              <strong>template</strong> can be used to set default values for all returned traces. It should be an
+              object (possibly null)
             </p>
-            <p><strong>Example:</strong></p>
-            <pre>
-              <code class="language-javascript">
-                import { dbPlot } from '/includes/tooldaq.js';
+            <p>
+              <strong>Example:</strong>
+            </p>
+            <pre><code class="language-javascript">import { dbPlot } from '/includes/tooldaq.js';
+const query = "SELECT time, data->'humidity' as \"humidity\", data->'temperature' as \"temperature\" FROM monitoring WHERE device ='test_device' ORDER BY time LIMIT 50";
+const template = { type: 'scatter', mode: 'lines+markers' };
 
-                const query = "SELECT time, data->'humidity' as \"humidity\", data->'temperature' as \"temperature\" FROM monitoring WHERE device ='test_device' ORDER BY time LIMIT 50";
-                const template = { type: 'scatter', mode: 'lines+markers' };
-
-                function runDbPlot() {
-                    dbPlot(query, template).then(plots => {
-                      if (!plots || plots.length === 0) {
-                        throw new Error("No data returned for plotting.");
-                      }
-                      Plotly.newPlot('plotContainer', plots);
-                    })
-                    .catch(error => {
-                      document.getElementById('plotContainer').innerHTML = `<p style="color:red;">Error: ${error.message}</p>`;
-                    });
-                }
-              </code>
-            </pre>
-            <pre>
-              <code class="language-html">
-                &lt;div id="plotContainer" class="demo-container mdl-shadow--2dp"&gt;&lt;/div&gt;
-                &lt;button onclick="runDbPlot()"
-                  class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored"&gt;
-                  Run dbPlot
-                &lt;/button&gt;
-              </code>
-            </pre>
+function runDbPlot() {
+  dbPlot(query, template).then(plots => {
+    if (!plots || plots.length === 0) {
+      throw new Error("No data returned for plotting.");
+    }
+    Plotly.newPlot('plotContainer', plots);
+  })
+  .catch(error => {
+    document.getElementById('plotContainer').innerHTML = `<p style="color:red;">Error: ${error.message}</p>`;
+  });
+}</code>
+<code class="language-html">&lt;div id="plotContainer" class="demo-container mdl-shadow--2dp"&gt;&lt;/div&gt;
+&lt;button onclick="runDbPlot()"
+  class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored"&gt;
+  Run dbPlot
+&lt;/button&gt;</code></pre>
             <p>
               <strong>Output:</strong> A plot will be rendered in a container element with the ID
               <code>plotContainer</code>.
@@ -280,7 +280,6 @@
                 });
               }
             </script>
-            <hr>
           </div>
         </div>
       </div>
@@ -289,4 +288,5 @@
   <!--#include virtual="/includes/footer.html" -->
   <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
 </body>
+
 </html>

--- a/html-Detector/SubSystemExample/intro/index.html
+++ b/html-Detector/SubSystemExample/intro/index.html
@@ -16,76 +16,104 @@
 
   <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
     <main class="mdl-layout__content">
-      <div class="content mdl-typography--text-center">
-        <h1>ToolDAQ.js Examples and Getting Started Guide</h1>
-        <p>This is your guide to using <strong>tooldaq.js</strong>;
-          a JavaScript library for interacting with the back-end services for monitoring and data systems, providing
-          functionalities for database queries, requests and data visualization.. ToolDAQ.js provides functionalities
-          for:
+      <div class="content">
+        <h2>Introduction</h2>
+        <p>
+          <strong>ToolDAQ.js</strong> is a JavaScript library for interacting with the back-end services
+          for monitoring and data systems, providing functionalities for database queries, requests and data
+          visualization. <strong>ToolDAQ.js</strong> provides functionalities for:
         </p>
         <ul class="mdl-typography--text-left">
-          <li><strong>Database Queries:</strong> Retrieve and manage data from ToolDAQ databases efficiently.</li>
-          <li><strong>Requests:</strong> Handle requests to interact with external services and endpoints.</li>
-          <li><strong>Data Visualization:</strong> Create plots and visualizations for data analysis.</li>
-          <li><strong>Service Management:</strong> Interact with and manage ToolDAQ services for seamless integration.</li>
+          <li><strong>Database Queries:</strong> Retrieve and manage structured data from the ToolDAQ databases
+            efficiently.</li>
+          <li><strong>Requests:</strong> Send and handle requests to interact with external services and endpoints.</li>
+          <li><strong>Data Visualization:</strong> Create plots and visualizations for data analysis using plotly.</li>
+          <li><strong>Service Management:</strong> Interact with and manage ToolDAQ services for seamless integration.
+          </li>
           <li><strong>Utilities:</strong> Miscellaneous helper functions to enhance development workflows.</li>
         </ul>
-      </div>
-      <div class="content">
-        <hr>
-        <h2>The functions have organised into the following groups for easy navigation</h2>
-        <p>They explore each of these function groups, providing examples and interactive demos for easier/better understanding.</p>
+        <p>
+          Examples of some of the functionalities are shown with interactive demonstrations on the following pages:
+        </p>
         <ul>
           <li><a href="/SubSystemExample/databaseQueries" class="documentation-link">Database Query Operations</a></li>
+          <li><a href="/SubSystemExample/plottingFunctions" class="documentation-link">Plotting and Visualization
+              Functions</a></li>
           <li><a href="/SubSystemExample/request" class="documentation-link">Request Functions</a></li>
-          <li><a href="/SubSystemExample/plottingFunctions" class="documentation-link">Plotting and Visualization Functions</a></li>
           <li><a href="/SubSystemExample/services" class="documentation-link">Service Functions</a></li>
         </ul>
         <hr>
+
+        <div id="practices">
+          <h2>Page Creation</h2>
+        <p>
+          To create a page called <code>myPage</code>, copy any of the existing directories in <code>html-Detector</code>. This should contain the following files:
+          <ul>
+            <li><code>myPage/index.html</code></li>
+            <li><code>myPage/subheader.html</code></li>
+            <li><code>myPage/tablist</code></li>
+          </ul>
+          Sub-pages can be stored in the <code>myPage</code> folder. This should just have an index page:
+          <ul>
+            <li><code>myPage/mySubPage/index.html</code></li>
+          </ul>
+          The page <code>index.html</code> should have the following format:
+          <pre><code class="language-html">&lt;!DOCTYPE html&gt;
+&lt;html lang="en"&gt;
+&lt;head&gt;
+  &lt;title&gt;Title&lt;/title&gt;
+&lt;/head&gt;
+&lt;body&gt;
+  &lt;!--#include virtual="/includes/header.html" --&gt;
+  &lt;!--#include virtual="subheader.html" --&gt;
+  &lt;!--#include virtual="/includes/drawer.html" --&gt;
+            
+  Content here
+            
+  &lt;!--#include virtual="/includes/footer.html" --&gt;
+&lt;/body&gt;
+&lt;/html&gt;</code></pre>
+        </p>
+        <hr>
+        </div>
+        
         <div id="setup">
-          <h2>Basic Setup</h2>
+          <h2>Importing ToolDAQ.js</h2>
           <p>
             To use <strong>ToolDAQ.js</strong> in your project, follow these steps:
           </p>
           <ol>
-            <li><strong>Set Up Your JavaScript File:</strong> Create a new JavaScript file (e.g., <code>app.js</code>)
+            <li>Create a new JavaScript file (e.g. <code>app.js</code>)
               where you'll write your code.</li>
-            <li><strong>Import ToolDAQ.js Functions:</strong> Use the ES6 <code>import</code> syntax to include the
-              functions you need from <code>tooldaq.js</code>. For example:
-              <pre class="mdl-typography--body-2">
-                <code class="language-javascript">import { dbJson } from '/includes/tooldaq.js';</code>
-              </pre>
+            <li>Import the functions you need from <code>tooldaq.js</code> by using the ES6 <code>import</code> syntax:
+              <pre><code class="language-javascript">import { dbJson } from '/includes/tooldaq.js';</code></pre>
 
-              If you need multiple functions, you can import them all at once:
-              <pre class="mdl-typography--body-2">
-                <code  class="language-javascript">import { dbJson, dbTable, dbPlot } from '/includes/tooldaq.js';</code>
-              </pre>
+              If you need multiple functions, you can import them simultaneously:
+              <pre><code class="language-javascript">import { dbJson, dbTable, dbPlot } from '/includes/tooldaq.js';</code></pre>
             </li>
-            <li><strong>Link Your JavaScript File to Your HTML Page:</strong> Add the following line to your HTML file
-              to
-              include your <code>app.js</code>:
-              <pre class="mdl-typography--body-2">
-                <code  class="language-html">
-                  &lt;html lang="en"&gt;
-                    &lt;head&gt;
-                      &lt;title&gt;ToolDAQ.js WebPage&lt;/title&gt;
-                    &lt;/head&gt;
-                    &lt;body&gt;
-                      &lt;!--#include virtual="/includes/header.html" --&gt;
-                      &lt;!--#include virtual="../subheader.html" --&gt;
-                      &lt;!--#include virtual="/includes/drawer.html" --&gt;
+            <li>Link your JavaScript file to your HTML page by adding the following line to your HTML file
+              to include your <code>app.js</code>:
+              <pre><code class="language-html">&lt;!DOCTYPE html&gt;
+&lt;html lang="en"&gt;
+&lt;head&gt;
+  &lt;title&gt;ToolDAQ.js WebPage&lt;/title&gt;
+&lt;/head&gt;
+&lt;body&gt;
+  &lt;!--#include virtual="/includes/header.html" --&gt;
+  &lt;!--#include virtual="../subheader.html" --&gt;
+  &lt;!--#include virtual="/includes/drawer.html" --&gt;
 
-                      &lt;h1&gt;ToolDAQ.js WebPage&lt;/h1&gt;
+  &lt;h1&gt;ToolDAQ.js WebPage&lt;/h1&gt;
 
-                      &lt;!--#include virtual="/includes/footer.html" --&gt;
-                      &lt;script src="app.js"&gt;&lt;/script&gt;
-                    &lt;/body&gt;
-                  &lt;/html&gt;
-                </code>
-              </pre>
+  &lt;!--#include virtual="/includes/footer.html" --&gt;
+  &lt;script src="app.js"&gt;&lt;/script&gt;
+&lt;/body&gt;
+&lt;/html&gt;</code></pre>
             </li>
           </ol>
-          <p>Once you've completed these steps, you're ready to start using ToolDAQ.js!</p>
+          <p>
+            Once you've completed these steps, you're ready to start using <strong>ToolDAQ.js</strong>!
+          </p>
         </div>
       </div>
     </main>

--- a/html-Detector/SubSystemExample/plottingFunctions/index.html
+++ b/html-Detector/SubSystemExample/plottingFunctions/index.html
@@ -24,16 +24,28 @@
             These functions are useful for visualizing data from the monitoring system and predefined Plotly plots.
           </p>
           <ul>
-            <li><a class="documentation-link" href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#getMonitoringPlot" target="_blank">getMonitoringPlot(device, options):</a> Retrieves monitoring data as an array of Plotly
+            <li><a class="documentation-link"
+                href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#getMonitoringPlot"
+                target="_blank">getMonitoringPlot(device, options):</a> Retrieves monitoring data as an array of Plotly
               plot objects.</li>
-            <li><a class="documentation-link" href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#makeMonitoringPlot" target="_blank">makeMonitoringPlot(div, device, options, layout):</a> Generates a plot and fills the
+            <li><a class="documentation-link"
+                href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#makeMonitoringPlot"
+                target="_blank">makeMonitoringPlot(div, device, options, layout):</a> Generates a plot and fills the
               specified div.</li>
-            <li><a class="documentation-link" href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#getPlotlyPlot" target="_blank">getPlotlyPlot(name, version):</a> Retrieves a saved Plotly plot.</li>
-            <li><a class="documentation-link" href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#makePlotlyPlot" target="_blank">makePlotlyPlot(div, name, version):</a> Renders a saved Plotly plot inside a specified div.
+            <li><a class="documentation-link"
+                href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#getPlotlyPlot"
+                target="_blank">getPlotlyPlot(name, version):</a> Retrieves a saved Plotly plot.</li>
+            <li><a class="documentation-link"
+                href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#makePlotlyPlot"
+                target="_blank">makePlotlyPlot(div, name, version):</a> Renders a saved Plotly plot inside a specified
+              div.
             </li>
           </ul>
-          <p>Below are detailed explanations and examples for each function:</p>
+          <p>
+            Below are detailed explanations and examples for each function:
+          </p>
 
+          <hr>
           <!-- getMonitoringPlot Example -->
           <div id="get-monitoring-plot-example">
             <h3>getMonitoringPlot(device, options)</h3>
@@ -45,49 +57,46 @@
               <code>options</code> (object): An object containing parameters for the request. options can be null in
               which case all monitoring data is returned <br>
             </p>
-            <p><strong>Example:</strong></p>
-            <pre>
-              <code class="language-javascript">
-                import { getMonitoringPlot } from '/includes/tooldaq.js';
-                const device = "test_device";
-                const options = {
-                  from: '2025-02-18 12:59:13.588877+00',
-                  to: new Date(),
-                  template: { mode: 'lines+markers' } };
-                getMonitoringPlot(device, options).then(plots => console.log(plots));
-              </code>
-            </pre>
-            <p><strong>Output:</strong> Logs the retrieved plot data to the console.</p>
+            <p>
+              <strong>Example:</strong>
+            </p>
+            <pre><code class="language-javascript">import { getMonitoringPlot } from '/includes/tooldaq.js';
+const device = "test_device";
+const options = {
+  from: '2025-02-18 12:59:13.588877+00',
+  to: new Date(),
+  template: { mode: 'lines+markers' } };
+getMonitoringPlot(device, options).then(plots => console.log(plots));</code></pre>
+            <p>
+              <strong>Output:</strong> Logs the retrieved plot data to the console.
+            </p>
             <p>
               You can also add as script tag directly to your HTML file: and utilise the function as shown below:
             </p>
-            <pre>
-              <code class="language-html">
-                &lt;button onclick="runGetMonitoringPlot()" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored"&gt;
-                  Run getMonitoringPlot
-                &lt;/button&gt;
-                &lt;div id="getMonitoringPlotOutput" class="mdl-typography--body-1"&gt;&lt;/div&gt;
+            <pre><code class="language-html">&lt;button onclick="runGetMonitoringPlot()" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored"&gt;
+  Run getMonitoringPlot
+&lt;/button&gt;
+&lt;div id="getMonitoringPlotOutput" class="mdl-typography--body-1"&gt;&lt;/div&gt;
 
-                &lt;script&gt;
-                  function runGetMonitoringPlot() {
-                    import('/includes/tooldaq.js').then(({ getMonitoringPlot }) => {
-                      const device = "test_device";
-                      const options = {
-                        from: '2025-02-18 12:59:13.588877+00',
-                        to: new Date(),
-                        template: { mode: 'lines+markers' } };
-                      getMonitoringPlot(device, options)
-                        .then(plots => {
-                          document.getElementById('getMonitoringPlotOutput').innerText = JSON.stringify(plots, null, 2);
-                        })
-                        .catch(error => {
-                          document.getElementById('getMonitoringPlotOutput').innerText = 'Error: ' + error.message;
-                        });
-                    });
-                  }
-                &lt;/script&gt;
-              </code>
-            </pre>
+&lt;script&gt;
+  function runGetMonitoringPlot() {
+    import('/includes/tooldaq.js').then(({ getMonitoringPlot }) => {
+      const device = "test_device";
+      const options = {
+        from: '2025-02-18 12:59:13.588877+00',
+        to: new Date(),
+        template: { mode: 'lines+markers' } 
+      };
+      getMonitoringPlot(device, options)
+        .then(plots => {
+          document.getElementById('getMonitoringPlotOutput').innerText = JSON.stringify(plots, null, 2);
+        })
+        .catch(error => {
+          document.getElementById('getMonitoringPlotOutput').innerText = 'Error: ' + error.message;
+        });
+    });
+  }
+&lt;/script&gt;</code></pre>
             <div class="demo-container">
               <button onclick="runGetMonitoringPlotDemo()"
                 class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored">
@@ -103,7 +112,8 @@
                   const options = {
                     from: '2025-02-18 12:59:13.588877+00',
                     to: new Date(),
-                    template: { mode: 'lines+markers' } };
+                    template: { mode: 'lines+markers' }
+                  };
                   getMonitoringPlot(device, options)
                     .then(plots => {
                       document.getElementById('getMonitoringPlotOutput').innerText = JSON.stringify(plots, null, 2);
@@ -129,39 +139,35 @@
               which case all monitoring data is returned <br>
               <code>layout</code> (object): An object containing layout options for the plot.
             </p>
-            <p><strong>Example:</strong></p>
-            <pre>
-              <code class="language-javascript">
-                import { makeMonitoringPlot } from '/includes/tooldaq.js';
-                const device = "middleman_1";
-                const options = { from: '2025-01-01T00:00:00Z' };
-                const layout = { title: "Sensor Data" };
-                makeMonitoringPlot("monitoringPlotContainer", device, options, layout);
-              </code>
-            </pre>
-            <p>You can also embed the script in your html using the snippet below</p>
-            <pre>
-              <code class="language-html">
-                &lt;div id="monitoringPlotContainer" class="demo-container mdl-shadow--2dp"&gt;&lt;/div&gt;
-                &lt;script&gt;
-                  <code class="language-javascript">
-                    function runMakeMonitoringPlot() {
-                      import('/includes/tooldaq.js').then(({ makeMonitoringPlot }) => {
-                        const device = "test_device";
-                        const options = {
-                          xaxis: { title: 'Time' },
-                          yaxis: { title: 'Sensor Values' },
-                          showlegend: true,
-                        };
-                        const layout = { title: "Sensor Data" };
-                        makeMonitoringPlot("monitoringPlotContainer", device, options, layout);
-                      });
-                    }
-                  </code>
-                &lt;/script&gt;
-              </code>
-            </pre>
-            <p><strong>Output:</strong> A plot will be rendered inside the div with the ID
+            <p>
+              <strong>Example:</strong>
+            </p>
+            <pre><code class="language-javascript">import { makeMonitoringPlot } from '/includes/tooldaq.js';
+const device = "middleman_1";
+const options = { from: '2025-01-01T00:00:00Z' };
+const layout = { title: "Sensor Data" };
+makeMonitoringPlot("monitoringPlotContainer", device, options, layout);</code></pre>
+            <p>
+              You can also embed the script in your html using the snippet below
+            </p>
+            <pre><code class="language-html">&lt;div id="monitoringPlotContainer" class="demo-container mdl-shadow--2dp"&gt;&lt;/div&gt;
+&lt;script&gt;
+<code class="language-javascript">function runMakeMonitoringPlot() {
+  import('/includes/tooldaq.js').then(({ makeMonitoringPlot }) => {
+    const device = "test_device";
+    const options = {
+      xaxis: { title: 'Time' },
+      yaxis: { title: 'Sensor Values' },
+      showlegend: true,
+    };
+      const layout = { title: "Sensor Data" };
+      makeMonitoringPlot("monitoringPlotContainer", device, options, layout);
+    });
+  }
+</code>
+&lt;/script&gt;</code></pre>
+            <p>
+              <strong>Output:</strong> A plot will be rendered inside the div with the ID
               <code>monitoringPlotContainer</code>.
             </p>
             <div id="monitoringPlotContainer" class="demo-container mdl-shadow--2dp">
@@ -198,24 +204,23 @@
               <code>name</code> (string): The name of the plot to retrieve. <br>
               <code>version</code> (number): The version of the plot to retrieve.
             </p>
-            <p><strong>Example:</strong></p>
-            <pre>
-              <code class="language-javascript">
-                import { getPlotlyPlot } from '/includes/tooldaq.js';
-                const name = "plotly1";
-                const version = 1;
-                function runGetPlotlyPlot() {
-                  getPlotlyPlot(name, version).then(plot => console.log(plot));
-                }
-              </code>
-              <code class="language-html">
-                &lt;button onclick="runGetPlotlyPlot()" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored"&gt;
-                  Run getPlotlyPlot
-                &lt;/button&gt;
-                &lt;div id="getPlotlyPlotOutput" class="mdl-typography--body-1"&gt;&lt;/div&gt;
-              </code>
-            </pre>
-            <p><strong>Output:</strong> Logs the retrieved plot data to the console.</p>
+            <p>
+              <strong>Example:</strong>
+            </p>
+            <pre><code class="language-javascript">import { getPlotlyPlot } from '/includes/tooldaq.js';
+const name = "plotly1";
+const version = 1;
+function runGetPlotlyPlot() {
+  getPlotlyPlot(name, version).then(plot => console.log(plot));
+}
+</code>
+<code class="language-html">&lt;button onclick="runGetPlotlyPlot()" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored"&gt;
+  Run getPlotlyPlot
+&lt;/button&gt;
+&lt;div id="getPlotlyPlotOutput" class="mdl-typography--body-1"&gt;&lt;/div&gt;</code></pre>
+            <p>
+              <strong>Output:</strong> Logs the retrieved plot data to the console.
+            </p>
             <div class="demo-container">
               <button onclick="runGetPlotlyPlotDemo()"
                 class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored">
@@ -253,25 +258,22 @@
               <code>name</code> (string): The name of the plot to retrieve. <br>
               <code>version</code> (number): The version of the plot to retrieve.
             </p>
-            <p><strong>Example:</strong></p>
-            <pre>
-              <code class="language-html">
-                &lt;button onclick="runMakePlotlyPlot()" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored"&gt;
-                  Run makePlotlyPlot
-                &lt;/button&gt;
-                &lt;div id="plotlyContainer" class="demo-container mdl-shadow--2dp"&gt;&lt;/div&gt;
-              </code>
-              <code class="language-javascript">
-                import { makePlotlyPlot } from '/includes/tooldaq.js';
+            <p>
+              <strong>Example:</strong>
+            </p>
+            <pre><code class="language-html">&lt;button onclick="runMakePlotlyPlot()" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored"&gt;
+  Run makePlotlyPlot
+&lt;/button&gt;
+&lt;div id="plotlyContainer" class="demo-container mdl-shadow--2dp"&gt;&lt;/div&gt;</code>
+<code class="language-javascript">
+import { makePlotlyPlot } from '/includes/tooldaq.js';
 
-                const divId = 'plotlyContainer';
-                const plotName = 'plotly1';
-                const plotVersion = 1;
-                function runMakePlotlyPlot() {
-                  makePlotlyPlot(divId, plotName, plotVersion);
-                }
-              </code>
-            </pre>
+const divId = 'plotlyContainer';
+const plotName = 'plotly1';
+const plotVersion = 1;
+function runMakePlotlyPlot() {
+  makePlotlyPlot(divId, plotName, plotVersion);
+}</code></pre>
             <p>
               <strong>Output:</strong> The plot will be rendered inside the <code>div</code> element with the ID
               <code>plotlyContainer</code>.
@@ -298,7 +300,6 @@
                 });
               }
             </script>
-            <hr>
           </div>
         </div>
       </div>

--- a/html-Detector/SubSystemExample/request/index.html
+++ b/html-Detector/SubSystemExample/request/index.html
@@ -17,60 +17,60 @@
   <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
     <main class="mdl-layout__content">
       <div class="content">
-        <hr>
         <div id="request-functions">
           <h2>Request Functions</h2>
-          <p>The request functions in ToolDAQ.js provide functionalities to interact with services and
-            endpoints.</p>
+          <p>
+            The request functions in ToolDAQ.js provide functionalities to interact with services and endpoints.
+          </p>
           <ul>
             <li>
-              <a class="documentation-link" href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#request" target="_blank"> getRequest(url, args, options) </a>
+              <a class="documentation-link"
+                href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#request" target="_blank">
+                getRequest(url, args, options) </a>
               Sends an HTTP request to url and returns a Promise to return a Response object.
               This is a low-level function, see below for functions that make a request and process the Response.
             </li>
           </ul>
+          <hr>
           <div id="get-request-example">
-            <h3><a class="documentation-link" href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#request" target="_blank">getRequest(url, args, options)</a></h3>
+            <h3>getRequest(url, args, options)</h3>
             <p>
               <strong>Description:</strong> Sends a GET request to the specified URL and returns the response. <br>
               <strong>Arguments:</strong>
-              <ul>
-                <li><code>url</code> (string): The URL to send the request to.</li>
-                <li><code>args</code> (object): The arguments to include in the request.</li>
-                <li><code>options</code> (object): The options to include in the request.</li>
-              </ul>
+            <ul>
+              <li><code>url</code> (string): The URL to send the request to.</li>
+              <li><code>args</code> (object): The arguments to include in the request.</li>
+              <li><code>options</code> (object): The options to include in the request.</li>
+            </ul>
             </p>
-            <p><strong>Example:</strong></p>
-            <pre>
-              <code class="language-html">
-                &lt;button onclick="runRequest()"
-                  class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored"&gt;
-                  Run getRequest
-                &lt;/button&gt;
-                &lt;div id="getRequestOutput" class="mdl-typography--body-1"&gt;&lt;/div&gt;
-              </code>
-            </pre>
-            <pre>
-              <code class="language-javascript">
-                import { getRequest } from '/includes/tooldaq.js';
+            <p>
+              <strong>Example:</strong>
+            </p>
+            <pre><code class="language-html">&lt;button onclick="runRequest()"
+  class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored"&gt;
+  Run getRequest
+&lt;/button&gt;
+&lt;div id="getRequestOutput" class="mdl-typography--body-1"&gt;&lt;/div&gt;</code>
 
-                // Example: Send a query request to the database
-                const url = '/cgi-bin/db-query.cgi';
-                const options = { query: 'select now()', format: 'json' }
-                function runRequest(){
-                  request(url, options).then(response => {
-                    response.json().then(data => {
-                      console.log(data);
-                    }).catch(error => {
-                      console.error('Error parsing JSON:', error);
-                    });
-                  }).catch(error => {
-                    console.error('Error:', error);
-                  });
-                }
-              </code>
-            </pre>
-            <p><strong>Output:</strong> Logs the response from the request to the console.</p>
+<code class="language-javascript">import { getRequest } from '/includes/tooldaq.js';
+
+// Example: Send a query request to the database
+const url = '/cgi-bin/db-query.cgi';
+const options = { query: 'select now()', format: 'json' }
+function runRequest(){
+  request(url, options).then(response => {
+    response.json().then(data => {
+      console.log(data);
+    }).catch(error => {
+      console.error('Error parsing JSON:', error);
+    });
+  }).catch(error => {
+    console.error('Error:', error);
+  });
+}</code></pre>
+            <p>
+              <strong>Output:</strong> Logs the response from the request to the console.
+            </p>
 
             <div class="demo-container">
               <button onclick="runGetRequestDemo()"
@@ -89,7 +89,7 @@
                     response.json().then(data => {
                       document.getElementById('getRequestOutput').innerText = JSON.stringify(data);
                     }).catch(error => {
-                        document.getElementById('getRequestOutput').innerText = 'Error parsing JSON: ' + error.message;
+                      document.getElementById('getRequestOutput').innerText = 'Error parsing JSON: ' + error.message;
                     });
                   }).catch(error => {
                     document.getElementById('getRequestOutput').innerText = 'Error: ' + error.message;
@@ -101,45 +101,38 @@
           </div>
 
           <div id="fetch-file">
-            <h3><a class="documentation-link" href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#request" target="_blank">Fetch File Contents</a></h3>
-            <p>Reads the contents of a log file.</p>
-            <pre>
-              <code class="language-javascript">
-                import { request } from '/includes/tooldaq.js';
+            <h3>Fetch File Contents</h3>
+            <p>
+              Reads the contents of a log file.
+            </p>
+            <pre><code class="language-javascript">import { request } from '/includes/tooldaq.js';
 
-                const url = '/logs/Example_log';
-                request(url).then(response => response.text()).then(text => {
-                  console.log(text);
-                }).catch(error => {
-                  console.error('Error:', error);
-                });
-              </code>
-            </pre>
-            <pre>
-              <code class="language-html">
-                &lt;button onclick="fetchFileContents()" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored"&gt;
-                  Run
-                &lt;/button&gt;
-                &lt;div id="fileOutput"&gt;&lt;/div&gt;
+const url = '/logs/Example_log';
+request(url).then(response => response.text()).then(text => {
+  console.log(text);
+}).catch(error => {
+  console.error('Error:', error);
+});</code>
+<code class="language-html">&lt;button onclick="fetchFileContents()" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored"&gt;
+  Run
+&lt;/button&gt;
+&lt;div id="fileOutput"&gt;&lt;/div&gt;
 
-                &lt;script&gt;
-                  <code class="language-javascript">
-                    function fetchFileContents() {
-                      import('/includes/tooldaq.js').then(({ request }) => {
-                        const url = '/logs/Example_log';
-                        request('/logs/Example_log').then(response => response.text()).then(text => {
-                          document.getElementById('fileOutput').innerText = text;
-                        }).catch(error => {
-                          document.getElementById('fileOutput').innerText = 'Error: ' + error.message;
-                        });
-                      });
-                    }
-                  </code>
-                &lt;/script&gt;
-              </code>
-            </pre>
+&lt;script&gt;
+<code class="language-javascript">  function fetchFileContents() {
+    import('/includes/tooldaq.js').then(({ request }) => {
+      const url = '/logs/Example_log';
+      request('/logs/Example_log').then(response => response.text()).then(text => {
+        document.getElementById('fileOutput').innerText = text;
+      }).catch(error => {
+        document.getElementById('fileOutput').innerText = 'Error: ' + error.message;
+      });
+    });
+  }</code>
+&lt;/script&gt;</code></pre>
             <div class="demo-container">
-              <button onclick="fetchFileContents()" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored">Run fetchFileContents</button>
+              <button onclick="fetchFileContents()"
+                class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored">Run fetchFileContents</button>
               <div id="fileOutput"></div>
             </div>
 
@@ -155,7 +148,6 @@
               }
             </script>
           </div>
-
         </div>
       </div>
     </main>

--- a/html-Detector/SubSystemExample/services/index.html
+++ b/html-Detector/SubSystemExample/services/index.html
@@ -18,49 +18,61 @@
     <main class="mdl-layout__content">
       <div class="content">
         <div id="services-functions">
-          <hr>
-          <h2 class="mdl-typography--headline">Services Functions</h2>
-          <hr>
-          <p>The services functions in ToolDAQ.js provide functionalities to interact with and manage services. </p>
+          <h2>Services Functions</h2>
+          <p>
+            The services functions in ToolDAQ.js provide functionalities to interact with and manage services.
+          </p>
           <ul>
-            <li><a class="documentation-link" href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#getservices" target="_blank">getServices(filter):</a> Returns an array of services matching the filter.</li>
-            <li><a class="documentation-link" href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#getservice" target="_blank">getService(name):</a> Returns a service matching name.</li>
-            <li><a class="documentation-link" href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#sendcommand" target="_blank">sendCommand(service, command, ...args):</a> Sends a command to a service and returns the service reply.</li>
-            <li><a class="documentation-link" href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#getcontrols" target="_blank">getControls(service):</a> Queries a service for slow controls that it supports.</li>
+            <li><a class="documentation-link"
+                href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#getservices"
+                target="_blank">getServices(filter):</a> Returns an array of services matching the filter.</li>
+            <li><a class="documentation-link"
+                href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#getservice"
+                target="_blank">getService(name):</a> Returns a service matching name.</li>
+            <li><a class="documentation-link"
+                href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#sendcommand"
+                target="_blank">sendCommand(service, command, ...args):</a> Sends a command to a service and returns the
+              service reply.</li>
+            <li><a class="documentation-link"
+                href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#getcontrols"
+                target="_blank">getControls(service):</a> Queries a service for slow controls that it supports.</li>
           </ul>
-          <p>Below are examples of each function</p>
+          <p>
+            Below are examples of each function.
+          </p>
+          <hr>
           <div id="get-services-example">
-            <h3><a class="documentation-link" href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#getservices" target="_blank">getServices(filter)</a></h3>
+            <h3>getServices(filter)</h3>
             <p>
               <strong>Description:</strong> Retrieves a list of available services.
             </p>
             <p>
               <strong>Arguments:</strong>
-              <ul>
-                <li><code>filter</code> (string): Accepts an optional filter parameter. The filter can be applied to the list of services.</li>
-              </ul>
+            <ul>
+              <li><code>filter</code> (string): Accepts an optional filter parameter. The filter can be applied to the
+                list of services.</li>
+            </ul>
             </p>
-            <p><strong>Example:</strong></p>
-            <pre>
-              <code class="language-html">
-                &lt;button onclick="runGetServices()"
-                  class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored"&gt;
-                  Run getServices
-                &lt;/button&gt;
-                &lt;div id="getServicesOutput" class="mdl-typography--body-1"&gt;&lt;/div&gt;
-              </code>
-              <code class="language-javascript">
-                import { getServices } from '/includes/tooldaq.js';
+            <p>
+              <strong>Example:</strong>
+            </p>
+            <pre><code class="language-html">&lt;button onclick="runGetServices()"
+  class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored"&gt;
+  Run getServices
+&lt;/button&gt;
+&lt;div id="getServicesOutput" class="mdl-typography--body-1"&gt;&lt;/div&gt;</code>
 
-                // Retrieve all services
-                function runGetServices() {
-                  getServices().then(
-                    document.getElementById('getServicesOutput').innerText = JSON.stringify(services, null, 2);
-                  );
-                }
-              </code>
-            </pre>
-            <p><strong>Output:</strong> Logs the filtered list of services to the console.</p>
+<code class="language-javascript">import { getServices } from '/includes/tooldaq.js';
+
+// Retrieve all services
+function runGetServices() {
+  getServices().then(
+  document.getElementById('getServicesOutput').innerText = JSON.stringify(services, null, 2);
+  );
+}</code></pre>
+            <p>
+              <strong>Output:</strong> Logs the filtered list of services to the console.
+            </p>
 
             <div class="demo-container">
               <button onclick="runGetServicesDemo()"
@@ -84,39 +96,35 @@
             <hr>
           </div>
           <div id="get-service-example">
-            <h3><a class="documentation-link" href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#getservice" target="_blank">getService(name)</a></h3>
+            <h3>getService(name)</h3>
             <p>
               <strong>Description:</strong> Retrieves a specific service by name. Returns null if the service is not
               found.
             </p>
             <p>
               <strong>Arguments:</strong>
-              <ul>
-                <li><code>name</code> (string): The name of the service to retrieve.</li>
-              </ul>
+            <ul>
+              <li><code>name</code> (string): The name of the service to retrieve.</li>
+            </ul>
             </p>
-            <p><strong>Example:</strong></p>
-            <pre>
-              <code class="language-javascript">
-                import { getService } from '/includes/tooldaq.js';
+            <p>
+              <strong>Example:</strong>
+            </p>
+            <pre><code class="language-javascript">import { getService } from '/includes/tooldaq.js';
+// Retrieve a specific service
+const serviceName = 'middleman_1';
+function runGetService() {
+  getService(serviceName).then(service => console.log(service));
+}</code>
 
-                // Retrieve a specific service
-                const serviceName = 'middleman_1';
-                function runGetService() {
-                  getService(serviceName).then(service => console.log(service));
-                }
-              </code>
-            </pre>
-            <pre>
-              <code class="language-html">
-                &lt;button onclick="runGetService()"
-                  class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored"&gt;
-                  Run getService
-                &lt;/button&gt;
-                &lt;div id="getServiceOutput" class="mdl-typography--body-1"&gt;&lt;/div&gt;
-              </code>
-            </pre>
-            <p><strong>Output:</strong> Logs the service details to the console.</p>
+<code class="language-html">&lt;button onclick="runGetService()"
+  class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored"&gt;
+  Run getService
+&lt;/button&gt;
+&lt;div id="getServiceOutput" class="mdl-typography--body-1"&gt;&lt;/div&gt;</code></pre>
+            <p>
+              <strong>Output:</strong> Logs the service details to the console.
+            </p>
 
             <div class="demo-container">
               <button onclick="runGetServiceDemo()"
@@ -140,57 +148,52 @@
             <hr>
           </div>
           <div id="send-command-example">
-            <h3><a class="documentation-link" href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#sendcommand" target="_blank">sendCommand(service, command, ...args)</a></h3>
+            <h3>sendCommand(service, command, ...args)</h3>
             <p>
               <strong>Description:</strong> Sends a command to a specified service. You can send any command with
               arguments to the service's command interface.
             </p>
             <p>
               <strong>Arguments:</strong>
-              <ul>
-                <li><code>service</code> (object): The service to send the command to.</li>
-                <li><code>command</code> (string): The command to send to the service.</li>
-                <li><code>...args</code> (any): The arguments to include in the command.</li>
-              </ul>
-            <p><strong>Example:</strong></p>
-            <pre>
-              <code class="language-javascript">
-                import { sendCommand } from '/includes/tooldaq.js';
+            <ul>
+              <li><code>service</code> (object): The service to send the command to.</li>
+              <li><code>command</code> (string): The command to send to the service.</li>
+              <li><code>...args</code> (any): The arguments to include in the command.</li>
+            </ul>
+            <p>
+              <strong>Example:</strong>
+            </p>
+            <pre><code class="language-javascript">import { sendCommand } from '/includes/tooldaq.js';
+// Example: Send a command to the service
+const service = { ip: '172.17.0.2', port: '24011' };
+const command = 'Status';
+sendCommand(service, command).then(response => console.log(response));</code></pre>
+            <p>
+              <strong>Output:</strong> Logs the response from the service to the console.
+            </p>
 
-                // Example: Send a command to the service
-                const service = { ip: '172.17.0.2', port: '24011' };
-                const command = 'Status';
-                sendCommand(service, command).then(response => console.log(response));
-              </code>
-            </pre>
-            <p><strong>Output:</strong> Logs the response from the service to the console.</p>
+            <p>
+              You can also use a script tag embedded in your html as follows:
+            </p>
+            <pre><code class="language-html">&lt;button onclick="runSendCommand()"
+  class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored"&gt;
+  Run sendCommand
+&lt;/button&gt;
+&lt;div id="sendCommandOutput" class="mdl-typography--body-1"&gt;&lt;/div&gt;
 
-            <p> You can also use a script tag embedded in your html as follows:</p>
-            <pre>
-              <code class="language-html">
-                &lt;button onclick="runSendCommand()"
-                  class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored"&gt;
-                  Run sendCommand
-                &lt;/button&gt;
-                &lt;div id="sendCommandOutput" class="mdl-typography--body-1"&gt;&lt;/div&gt;
-
-                &lt;script&gt;
-                  <code class="language-javascript">
-                    function runSendCommand() {
-                      import('/includes/tooldaq.js').then(({ sendCommand }) => {
-                        const service = { ip: '172.17.0.2', port: '24011' };
-                        const command = 'Status';
-                        sendCommand(service, command).then(response => {
-                          document.getElementById('sendCommandOutput').innerText = JSON.stringify(response, null, 2);
-                        }).catch(error => {
-                          document.getElementById('sendCommandOutput').innerText = 'Error: ' + error.message;
-                        });
-                      });
-                    }
-                  </code>
-                &lt;/script&gt;
-              </code>
-            </pre>
+&lt;script&gt;
+<code class="language-javascript">  function runSendCommand() {
+    import('/includes/tooldaq.js').then(({ sendCommand }) => {
+      const service = { ip: '172.17.0.2', port: '24011' };
+      const command = 'Status';
+      sendCommand(service, command).then(response => {
+        document.getElementById('sendCommandOutput').innerText = JSON.stringify(response, null, 2);
+      }).catch(error => {
+        document.getElementById('sendCommandOutput').innerText = 'Error: ' + error.message;
+      });
+    });
+  }</code>
+&lt;/script&gt;</code></pre>
 
             <div class="demo-container">
               <button onclick="runSendCommandDemo()"
@@ -216,39 +219,35 @@
             <hr>
           </div>
           <div id="get-controls-example">
-            <h3><a class="documentation-link" href="https://github.com/ToolDAQ/WebServer/blob/master/docs/tooldaq.mkd#getcontrols" target="_blank">getControls(service)</a></h3>
+            <h3>getControls(service)</h3>
             <p>
               <strong>Description:</strong> Retrieves the control interface (as JSON) for a specified service.
             </p>
             <p>
               <strong>Arguments:</strong>
-              <ul>
-                <li><code>service</code> (object): The service to retrieve the control interface for.</li>
-              </ul>
+            <ul>
+              <li><code>service</code> (object): The service to retrieve the control interface for.</li>
+            </ul>
             </p>
-            <p><strong>Example:</strong></p>
-            <pre>
-              <code class="language-javascript">
-                import { getControls } from '/includes/tooldaq.js';
+            <p>
+              <strong>Example:</strong>
+            </p>
+            <pre><code class="language-javascript">import { getControls } from '/includes/tooldaq.js';
+// Retrieve the controls for a service
+const service = { ip: '172.17.0.2', port: '24011' };
+function runGetControls() {
+  // getControls(service).then(controls => console.log(controls));
+  document.getElementById('getControlsOutput').innerText = JSON.stringify(controls, null, 2);
+}</code>
 
-                // Retrieve the controls for a service
-                const service = { ip: '172.17.0.2', port: '24011' };
-                function runGetControls() {
-                  // getControls(service).then(controls => console.log(controls));
-                  document.getElementById('getControlsOutput').innerText = JSON.stringify(controls, null, 2);
-                }
-              </code>
-            </pre>
-            <pre>
-              <code class="language-html">
-                &lt;button onclick="runGetControls()"
-                  class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored"&gt;
-                  Run getControls
-                &lt;/button&gt;
-                &lt;div id="getControlsOutput" class="mdl-typography--body-1"&gt;&lt;/div&gt;
-              </code>
-            </pre>
-            <p><strong>Output:</strong> Logs the retrieved controls for the service to the console.</p>
+<code class="language-html">&lt;button onclick="runGetControls()"
+  class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored"&gt;
+  Run getControls
+&lt;/button&gt;
+&lt;div id="getControlsOutput" class="mdl-typography--body-1"&gt;&lt;/div&gt;</code></pre>
+            <p>
+              <strong>Output:</strong> Logs the retrieved controls for the service to the console.
+            </p>
 
             <div class="demo-container">
               <button onclick="runGetControlsDemo()"
@@ -270,7 +269,6 @@
                 });
               }
             </script>
-            <hr>
           </div>
 
         </div>


### PR DESCRIPTION
I've tried to make formatting more consistent between stylesheets. The main changes are:

- Fix whitespace issues in html code blocks; code lines should be indented starting from the left after the initial pre and code elements.
- Made consistent use of hr to separate sub-sections.
- Made consistent use of headers to separate sections and sub-sections.
- Removed redundant text and fixed various typos.
- Lots of random fixes with html elements missing or incorrectly used.